### PR TITLE
Add 2nd step of auth handshake. 

### DIFF
--- a/twitter.go
+++ b/twitter.go
@@ -79,12 +79,16 @@ func SetConsumerSecret(consumer_secret string) {
 //AuthorizationURL generates the authorization URL for the first part of the OAuth handshake.
 //Redirect the user to this URL.
 //This assumes that the consumer key has already been set (using SetConsumerKey).
-func AuthorizationURL(callback string) (string, error) {
+func AuthorizationURL(callback string) (string, *oauth.Credentials, error) {
 	tempCred, err := oauthClient.RequestTemporaryCredentials(http.DefaultClient, callback, nil)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	return oauthClient.AuthorizationURL(tempCred, nil), nil
+	return oauthClient.AuthorizationURL(tempCred, nil), tempCred, nil
+}
+
+func GetCredentials(tempCred *oauth.Credentials, verifier string) (*oauth.Credentials, url.Values, error) {
+  return oauthClient.RequestToken(http.DefaultClient, tempCred, verifier)
 }
 
 func cleanValues(v url.Values) url.Values {


### PR DESCRIPTION
Return temporary credentials from first step for storage and verification in 2nd step.

I made this change to simplify the Oauth 1.0 authentication process for the Twitter API. In my test application the flow for signin with Twitter can now be fairly simple functions. Getting the temporary credentials out from AuthorizationURL() is necessary to properly sign the post request in step 2.

```
func SignInRedirect(w http.ResponseWriter, r *http.Request) {
  var authURL string
  var err error
  authURL, tempCred, err = anaconda.AuthorizationURL("http://127.0.0.1:9000/callback/")

  // Store tempCred in DB

  if err != nil {
    http.Error(w, fmt.Sprintf("Internal Error!: %s", err), http.StatusInternalServerError)
    return
  }

  // Redirect to Twitter.
  http.Redirect(w, r, authURL, 302)
}

func AfterSignIn(w http.ResponseWriter, r *http.Request) {
  err := r.ParseForm()
  if err != nil {
    http.Error(w, fmt.Sprintf("Error! %s\n", err), http.StatusInternalServerError)
    return
  }
  verifier := r.Form["oauth_verifier"][0]

  tempCred := GetFromDatabase()

  // Make POST request:
  credentials, vals, err := anaconda.GetCredentials(tempCred, verifier)
  if err != nil {
    http.Error(w, fmt.Sprintf("Error! %s\n", err), http.StatusInternalServerError)
    return
  }

  if credentials == nil {
    http.Error(w, "Credentials are nil!", http.StatusInternalServerError)
    return
  }

  // Create TwitterAPI object
  //twitterApi := anaconda.TwitterApi{credentials}

  // Store login cookie, 
}
```
