### PR TITLE
Use BaseUrl so https errors dont go missed

### DIFF
--- a/account.go
+++ b/account.go
@@ -18,6 +18,6 @@ func (a TwitterApi) VerifyCredentials() (ok bool, err error) {
 func (a TwitterApi) GetSelf(v url.Values) (u User, err error) {
 	v = cleanValues(v)
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/account/verify_credentials.json", v, &u, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "/account/verify_credentials.json", v, &u, _GET, response_ch}
 	return u, (<-response_ch).err
 }

--- a/directmessages.go
+++ b/directmessages.go
@@ -6,18 +6,18 @@ import (
 
 func (a TwitterApi) GetDirectMessages(v url.Values) (messages []DirectMessage, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/direct_messages.json", v, &messages, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "/direct_messages.json", v, &messages, _GET, response_ch}
 	return messages, (<-response_ch).err
 }
 
 func (a TwitterApi) GetDirectMessagesSent(v url.Values) (messages []DirectMessage, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/direct_messages_sent.json", v, &messages, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "/direct_messages_sent.json", v, &messages, _GET, response_ch}
 	return messages, (<-response_ch).err
 }
 
 func (a TwitterApi) GetDirectMessagesShow(v url.Values) (messages []DirectMessage, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/direct_messages/show.json", v, &messages, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "/direct_messages/show.json", v, &messages, _GET, response_ch}
 	return messages, (<-response_ch).err
 }

--- a/friends_followers.go
+++ b/friends_followers.go
@@ -39,7 +39,7 @@ type FollowersPage struct {
 //It does not currently support the stringify_ids parameter
 func (a TwitterApi) GetFriendshipsNoRetweets() (ids []int64, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/friendships/no_retweets/ids.json", nil, &ids, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "https://api.twitter.com/1.1/friendships/no_retweets/ids.json", nil, &ids, _GET, response_ch}
 	return ids, (<-response_ch).err
 }
 
@@ -50,31 +50,31 @@ func (a TwitterApi) GetFollowersIds(v url.Values) (c Cursor, err error) {
 
 func (a TwitterApi) GetFriendsIds(v url.Values) (c Cursor, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/friends/ids.json", v, &c, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "https://api.twitter.com/1.1/friends/ids.json", v, &c, _GET, response_ch}
 	return c, (<-response_ch).err
 }
 
 func (a TwitterApi) GetFriendshipsLookup(v url.Values) (friendships []Friendship, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/friendships/lookup.json", v, &friendships, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "https://api.twitter.com/1.1/friendships/lookup.json", v, &friendships, _GET, response_ch}
 	return friendships, (<-response_ch).err
 }
 
 func (a TwitterApi) GetFriendshipsIncoming(v url.Values) (c Cursor, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/friendships/incoming.json", v, &c, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "https://api.twitter.com/1.1/friendships/incoming.json", v, &c, _GET, response_ch}
 	return c, (<-response_ch).err
 }
 
 func (a TwitterApi) GetFriendshipsOutgoing(v url.Values) (c Cursor, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/friendships/outgoing.json", v, &c, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "https://api.twitter.com/1.1/friendships/outgoing.json", v, &c, _GET, response_ch}
 	return c, (<-response_ch).err
 }
 
 func (a TwitterApi) GetFollowersList(v url.Values) (c UserCursor, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/followers/list.json", v, &c, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "https://api.twitter.com/1.1/followers/list.json", v, &c, _GET, response_ch}
 	return c, (<-response_ch).err
 }
 
@@ -113,6 +113,6 @@ func (a TwitterApi) GetFollowersListAll(v url.Values) (result chan FollowersPage
 // This channel is closed once all values have been fetched
 func (a TwitterApi) GetFriendsIdsAll(v url.Values) (c Cursor, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/friends/ids.json", v, &c, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "https://api.twitter.com/1.1/friends/ids.json", v, &c, _GET, response_ch}
 	return c, (<-response_ch).err
 }

--- a/oembed.go
+++ b/oembed.go
@@ -22,7 +22,7 @@ type OEmbed struct {
 
 // No authorization on this endpoint. Its the only one.
 func (a TwitterApi) GetOEmbed(v url.Values) (o OEmbed, err error) {
-	resp, err := http.Get("https://api.twitter.com/1/statuses/oembed.json?" + v.Encode())
+	resp, err := http.Get(BaseUrlV1 + "/statuses/oembed.json?" + v.Encode())
 	if err != nil {
 		return
 	}
@@ -38,7 +38,7 @@ func (a TwitterApi) GetOEmbedId(id int64, v url.Values) (o OEmbed, err error) {
 		v = url.Values{}
 	}
 	v.Set("id", strconv.FormatInt(id, 10))
-	resp, err := http.Get("https://api.twitter.com/1/statuses/oembed.json?" + v.Encode())
+	resp, err := http.Get(BaseUrlV1 + "/statuses/oembed.json?" + v.Encode())
 	if err != nil {
 		return
 	}

--- a/search.go
+++ b/search.go
@@ -15,7 +15,7 @@ func (a TwitterApi) GetSearch(queryString string, v url.Values) (timeline []Twee
 	v.Set("q", queryString)
 
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/search/tweets.json", v, &sr, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "/search/tweets.json", v, &sr, _GET, response_ch}
 
 	// We have to read from the response channel before assigning to timeline
 	// Otherwise this will happen before the responses have been written

--- a/timeline.go
+++ b/timeline.go
@@ -9,24 +9,24 @@ func (a TwitterApi) GetHomeTimeline() (timeline []Tweet, err error) {
 	v.Set("include_entities", "true")
 
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/statuses/home_timeline.json", v, &timeline, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "/statuses/home_timeline.json", v, &timeline, _GET, response_ch}
 	return timeline, (<-response_ch).err
 }
 
 func (a TwitterApi) GetUserTimeline(v url.Values) (timeline []Tweet, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/statuses/user_timeline.json", v, &timeline, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "/statuses/user_timeline.json", v, &timeline, _GET, response_ch}
 	return timeline, (<-response_ch).err
 }
 
 func (a TwitterApi) GetMentionsTimeline(v url.Values) (timeline []Tweet, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/statuses/mentions_timeline.json", v, &timeline, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "/statuses/mentions_timeline.json", v, &timeline, _GET, response_ch}
 	return timeline, (<-response_ch).err
 }
 
 func (a TwitterApi) GetRetweetsOfMe(v url.Values) (tweets []Tweet, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/statuses/retweets_of_me.json", v, &tweets, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "/statuses/retweets_of_me.json", v, &tweets, _GET, response_ch}
 	return tweets, (<-response_ch).err
 }

--- a/tweets.go
+++ b/tweets.go
@@ -11,13 +11,13 @@ func (a TwitterApi) GetTweet(id int64, v url.Values) (tweet Tweet, err error) {
 	v.Set("id", strconv.FormatInt(id, 10))
 
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/statuses/show.json", v, &tweet, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "/statuses/show.json", v, &tweet, _GET, response_ch}
 	return tweet, (<-response_ch).err
 }
 
 func (a TwitterApi) GetRetweets(id int64, v url.Values) (tweets []Tweet, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{fmt.Sprintf("https://api.twitter.com/1.1/statuses/retweets/%d.json", id), v, &tweets, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + fmt.Sprintf("/statuses/retweets/%d.json", id), v, &tweets, _GET, response_ch}
 	return tweets, (<-response_ch).err
 }
 
@@ -26,7 +26,7 @@ func (a TwitterApi) PostTweet(status string, v url.Values) (tweet Tweet, err err
 	v = cleanValues(v)
 	v.Set("status", status)
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/statuses/update.json", v, &tweet, _POST, response_ch}
+	a.queryQueue <- query{BaseUrl + "/statuses/update.json", v, &tweet, _POST, response_ch}
 	return tweet, (<-response_ch).err
 }
 
@@ -38,7 +38,7 @@ func (a TwitterApi) DeleteTweet(id int64, trimUser bool) (tweet Tweet, err error
 		v.Set("trim_user", "t")
 	}
 	response_ch := make(chan response)
-	a.queryQueue <- query{fmt.Sprintf("https://api.twitter.com/1.1/statuses/destroy/%d.json", id), v, &tweet, _POST, response_ch}
+	a.queryQueue <- query{BaseUrl + fmt.Sprintf("/statuses/destroy/%d.json", id), v, &tweet, _POST, response_ch}
 	return tweet, (<-response_ch).err
 }
 
@@ -50,6 +50,6 @@ func (a TwitterApi) Retweet(id int64, trimUser bool) (rt Tweet, err error) {
 		v.Set("trim_user", "t")
 	}
 	response_ch := make(chan response)
-	a.queryQueue <- query{fmt.Sprintf("https://api.twitter.com/1.1/statuses/retweet/%d.json", id), v, &rt, _POST, response_ch}
+	a.queryQueue <- query{BaseUrl + fmt.Sprintf("/statuses/retweet/%d.json", id), v, &rt, _POST, response_ch}
 	return rt, (<-response_ch).err
 }

--- a/twitter.go
+++ b/twitter.go
@@ -53,6 +53,8 @@ import (
 const (
 	_GET  = iota
 	_POST = iota
+  BaseUrlV1 = "https://api.twitter.com/1"
+  BaseUrl = "https://api.twitter.com/1.1"
 )
 
 var oauthClient = oauth.Client{

--- a/users.go
+++ b/users.go
@@ -9,7 +9,7 @@ func (a TwitterApi) GetUsersLookup(usernames string, v url.Values) (u []User, er
 	v = cleanValues(v)
 	v.Set("screen_name", usernames)
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/users/lookup.json", v, &u, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "/users/lookup.json", v, &u, _GET, response_ch}
 	return u, (<-response_ch).err
 }
 
@@ -24,7 +24,7 @@ func (a TwitterApi) GetUsersLookupByIds(ids []int64, v url.Values) (u []User, er
 	}
 	v = cleanValues(v)
 	v.Set("user_id", pids)
-	err = a.apiGet("https://api.twitter.com/1.1/users/lookup.json", v, &u)
+	err = a.apiGet("/users/lookup.json", v, &u)
 	return
 }
 
@@ -32,7 +32,7 @@ func (a TwitterApi) GetUsersShow(username string, v url.Values) (u User, err err
 	v = cleanValues(v)
 	v.Set("screen_name", username)
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/users/show.json", v, &u, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "/users/show.json", v, &u, _GET, response_ch}
 	return u, (<-response_ch).err
 }
 
@@ -40,6 +40,6 @@ func (a TwitterApi) GetUsersShowById(id int64, v url.Values) (u User, err error)
 	v = cleanValues(v)
 	v.Set("user_id", strconv.FormatInt(id, 10))
 	response_ch := make(chan response)
-	a.queryQueue <- query{"https://api.twitter.com/1.1/users/show.json", v, &u, _GET, response_ch}
+	a.queryQueue <- query{BaseUrl + "/users/show.json", v, &u, _GET, response_ch}
 	return u, (<-response_ch).err
 }


### PR DESCRIPTION
There were a bunch of http errors today as they shut down http access (only allowing https). Seemed like a good time to clean up all the repeated text everywhere. I replaced every instance of `"https://api.twitter.com/1.1` with `BaseUrl + "` and set `BaseUrl` at the top of `twitter.go`.
