### PR TITLE
Don't close the stream if it's already closed

### DIFF
--- a/streaming.go
+++ b/streaming.go
@@ -124,7 +124,9 @@ type Stream struct {
 }
 
 func (s Stream) Close() error {
-	close(s.C)
+	if _, ok := <-s.C; ok {
+		close(s.C)
+	}
 	return s.response.Body.Close()
 }
 


### PR DESCRIPTION
Fixes a `panic: close of closed channel` when calling `Stream.Close()`.