### PR TITLE
Added support for /help/configuration.json

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -1,0 +1,32 @@
+package anaconda
+
+import (
+	"net/url"
+)
+
+type Configuration struct {
+	CharactersReservedPerMedia int      `json:"characters_reserved_per_media"`
+	MaxMediaPerUpload          int      `json:"max_media_per_upload"`
+	NonUsernamePaths           []string `json:"non_username_paths"`
+	PhotoSizeLimit             int      `json:"photo_size_limit"`
+	PhotoSizes                 struct {
+		Thumb  photoSize `json:"thumb"`
+		Small  photoSize `json:"small"`
+		Medium photoSize `json:"medium"`
+		Large  photoSize `json:"large"`
+	} `json:"photo_sizes"`
+	ShortUrlLength      int `json:"short_url_length"`
+	ShortUrlLengthHttps int `json:"short_url_length_https"`
+}
+
+type photoSize struct {
+	H      int    `json:"h"`
+	W      int    `json:"w"`
+	Resize string `json:"resize"`
+}
+
+func (a TwitterApi) GetConfiguration(v url.Values) (conf Configuration, err error) {
+	response_ch := make(chan response)
+	a.queryQueue <- query{BaseUrl + "/help/configuration.json", v, &conf, _GET, response_ch}
+	return conf, (<-response_ch).err
+}


### PR DESCRIPTION
It's a simple extension to add support for Twitters public configuration [1]. This can be used e.g. to check the character length of t.co shortlinks periodically when automating tweets with links. 

The new file exposes a single function GetConfiguration that returns a struct containing parsed json.

[1] https://dev.twitter.com/rest/reference/get/help/configuration