### PR TITLE
Adding support for `/list/members.json` end point

### DIFF
--- a/list.go
+++ b/list.go
@@ -6,6 +6,12 @@ type ListResponse struct {
 	Lists          []List `json:"lists"`
 }
 
+type ListMembersResponse struct {
+	PreviousCursor int    `json:"previous_cursor"`
+	NextCursor     int    `json:"next_cursor"`
+	Users          []User `json:"users"`
+}
+
 type AddUserToListResponse struct {
 	Users []User `json:"users"`
 }

--- a/lists.go
+++ b/lists.go
@@ -49,6 +49,22 @@ func (a TwitterApi) GetListsOwnedBy(userID int64, v url.Values) (lists []List, e
 	return listResponse.Lists, (<-response_ch).err
 }
 
+// GetListMembers implements /lists/members.json
+// count, and cursor are all optional values
+func (a TwitterApi) GetListMembers(listID int64, v url.Values) (users []User, err error) {
+	if v == nil {
+		v = url.Values{}
+	}
+	v.Set("list_id", strconv.FormatInt(listID, 10))
+	v.Set("skip_status", strconv.FormatBool(true))
+
+	var listMembersResponse ListMembersResponse
+
+	response_ch := make(chan response)
+	a.queryQueue <- query{BaseUrl + "/lists/members.json", v, &listMembersResponse, _GET, response_ch}
+	return listMembersResponse.Users, (<-response_ch).err
+}
+
 func (a TwitterApi) GetListTweets(listID int64, includeRTs bool, v url.Values) (tweets []Tweet, err error) {
 	if v == nil {
 		v = url.Values{}


### PR DESCRIPTION
This PR implements support for the `/list/members.json` end point ([doc](https://dev.twitter.com/rest/reference/get/lists/members)).

It just gets the list ID as a parameter and returns a `[]User`.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/chimeracoder/anaconda/67)

<!-- Reviewable:end -->
