### PR TITLE
Added support for /media/upload.json

### DIFF
--- a/media.go
+++ b/media.go
@@ -22,6 +22,6 @@ func (a TwitterApi) UploadMedia(base64String string) (media Media, err error) {
 	var mediaResponse Media
 
 	response_ch := make(chan response)
-	a.queryQueue <- query{BaseUrl + "/media/upload.json", v, &mediaResponse, _POST, response_ch}
+	a.queryQueue <- query{UploadBaseUrl + "/media/upload.json", v, &mediaResponse, _POST, response_ch}
 	return mediaResponse, (<-response_ch).err
 }

--- a/media.go
+++ b/media.go
@@ -1,0 +1,27 @@
+package anaconda
+
+import "net/url"
+
+type Media struct {
+	MediaID       int64  `json:"media_id"`
+	MediaIDString string `json:"media_id_string"`
+	Size          int    `json:"size"`
+	Image         Image  `json:"image"`
+}
+
+type Image struct {
+	W         int    `json:"w"`
+	H         int    `json:"h"`
+	ImageType string `json:"image_type"`
+}
+
+func (a TwitterApi) UploadMedia(base64String string) (media Media, err error) {
+	v := url.Values{}
+	v.Set("media", base64String)
+
+	var mediaResponse Media
+
+	response_ch := make(chan response)
+	a.queryQueue <- query{BaseUrl + "/media/upload.json", v, &mediaResponse, _POST, response_ch}
+	return mediaResponse, (<-response_ch).err
+}

--- a/twitter.go
+++ b/twitter.go
@@ -52,10 +52,11 @@ import (
 )
 
 const (
-	_GET      = iota
-	_POST     = iota
-	BaseUrlV1 = "https://api.twitter.com/1"
-	BaseUrl   = "https://api.twitter.com/1.1"
+	_GET          = iota
+	_POST         = iota
+	BaseUrlV1     = "https://api.twitter.com/1"
+	BaseUrl       = "https://api.twitter.com/1.1"
+	UploadBaseUrl = "https://upload.twitter.com/1.1"
 )
 
 var oauthClient = oauth.Client{


### PR DESCRIPTION
This PR implements support for the /media/upload.json end point

doc : https://dev.twitter.com/rest/reference/post/media/upload

it just return Media object.