### PR TITLE
Transports

### DIFF
--- a/twitter.go
+++ b/twitter.go
@@ -135,6 +135,9 @@ func SetConsumerSecret(consumer_secret string) {
 	oauthClient.Credentials.Secret = consumer_secret
 }
 
+// SetHttpTransport will set another RoundTripper instance instead of DefaultTransport. This is
+// particularly usefull when using this library in some resitricted environments like GAE.
+// see https://developers.google.com/appengine/docs/go/urlfetch
 func SetHttpTransport(transport http.RoundTripper) {
     httpTransport = transport
 }


### PR DESCRIPTION
Make it possible to provide another RoundTrip Transport to http.Client.

This because limitations of some PaaS providers like GAE which does not allow DefaultClient and DefaultTransport.

Changes does not break any of existing functionalists.

See: https://developers.google.com/appengine/docs/go/urlfetch