### PR TITLE
How to use Anaconda with Google App Engine

### DIFF
--- a/README
+++ b/README
@@ -92,6 +92,15 @@ To turn off automatic throttling, set the delay to `0`:
     api.SetDelay(0 * time.Second)
 ````
 
+### Google App Engine
+
+Since Google App Engine doesn't make the standard `http.Transport` available, it's necessary to tell Anaconda to use a different client context.
+
+````go
+	api = anaconda.NewTwitterApi("", "")
+	c := appengine.NewContext(r)
+	api.HttpClient.Transport = &urlfetch.Transport{Context: c}
+````
 
 
 License


### PR DESCRIPTION
Added a short section to the README. It has instructions on using Anaconda with Google App Engine.