### PR TITLE
Add default to streaming loop status code log.

### DIFF
--- a/streaming.go
+++ b/streaming.go
@@ -277,6 +277,8 @@ func (s Stream) loop(urlStr string, v url.Values, method int) {
 				s.Quit <- true
 				// trigger quit but donnot close chan
 				return
+			default:
+				s.api.Log.Notice("Received unknown status: %+s", resp.StatusCode)
 			}
 
 		}


### PR DESCRIPTION
In the Stream.loop function, the switch on the resp.StatusCode does not handle
unkown status codes.

For example, if you receive a 416 the user receives no notice of this failure
and only sees a problem when you enter the 420 timeout state.