### PR TITLE
add lowercase json field names for tweet entities

### DIFF
--- a/twitter_entities.go
+++ b/twitter_entities.go
@@ -2,62 +2,62 @@ package anaconda
 
 type UrlEntity struct {
 	Urls []struct {
-		Indices      []int
-		Url          string
-		Display_url  string
-		Expanded_url string
-	}
+		Indices      []int  `json:"indicies"`
+		Url          string `json:"url"`
+		Display_url  string `json:"display_url"`
+		Expanded_url string `json:"expanded_url"`
+	} `json:"urls"`
 }
 
 type Entities struct {
 	Hashtags []struct {
-		Indices []int
-		Text    string
-	}
+		Indices []int  `json:"indices"`
+		Text    string `json:"text"`
+	} `json:"hashtags"`
 	Urls []struct {
-		Indices      []int
-		Url          string
-		Display_url  string
-		Expanded_url string
-	}
-	Url           UrlEntity
+		Indices      []int  `json:"indices"`
+		Url          string `json:"url"`
+		Display_url  string `json:"display_url"`
+		Expanded_url string `json:"expanded_url"`
+	} `json:"urls"`
+	Url           UrlEntity `json:"url"`
 	User_mentions []struct {
-		Name        string
-		Indices     []int
-		Screen_name string
-		Id          int64
-		Id_str      string
-	}
-	Media []EntityMedia
+		Name        string `json:"name"`
+		Indices     []int  `json:"indices"`
+		Screen_name string `json:"screen_name"`
+		Id          int64  `json:"id"`
+		Id_str      string `json:"id_str"`
+	} `json:"user_mentions"`
+	Media []EntityMedia `json:"media"`
 }
 
 type EntityMedia struct {
-	Id                   int64
-	Id_str               string
-	Media_url            string
-	Media_url_https      string
-	Url                  string
-	Display_url          string
-	Expanded_url         string
-	Sizes                MediaSizes
-	Source_status_id     int64
-	Source_status_id_str string
-	Type                 string
-	Indices              []int
-	VideoInfo            VideoInfo `json:"video_info"`
+	Id                   int64      `json:"id"`
+	Id_str               string     `json:"id_str"`
+	Media_url            string     `json:"media_url"`
+	Media_url_https      string     `json:"media_url_https"`
+	Url                  string     `json:"url"`
+	Display_url          string     `json:"display_url"`
+	Expanded_url         string     `json:"expanded_url"`
+	Sizes                MediaSizes `json:"sizes"`
+	Source_status_id     int64      `json:"source_status_id"`
+	Source_status_id_str string     `json:"source_status_id_str"`
+	Type                 string     `json:"type"`
+	Indices              []int      `json:"indices"`
+	VideoInfo            VideoInfo  `json:"video_info"`
 }
 
 type MediaSizes struct {
-	Medium MediaSize
-	Thumb  MediaSize
-	Small  MediaSize
-	Large  MediaSize
+	Medium MediaSize `json:"medium"`
+	Thumb  MediaSize `json:"thumb"`
+	Small  MediaSize `json:"small"`
+	Large  MediaSize `json:"large"`
 }
 
 type MediaSize struct {
-	W      int
-	H      int
-	Resize string
+	W      int    `json:"w"`
+	H      int    `json:"h"`
+	Resize string `json:"resize"`
 }
 
 type VideoInfo struct {


### PR DESCRIPTION
This PR adds lowercase field names for the structs in twitter_entities. This is nice for those of us who use the library to encode Go obj instances back into JSON strings.
