### PR TITLE
Fix Entities serialization

### DIFF
--- a/twitter_entities.go
+++ b/twitter_entities.go
@@ -17,7 +17,7 @@ type UserMentions struct {
 	Indices    []int  `json:"indices"`
 	ScreenName string `json:"screen_name"`
 	Id         int64  `json:"id"`
-	Id_str     string `json:"id_str"`
+	IdStr      string `json:"id_str"`
 }
 
 type Entities struct {
@@ -29,7 +29,7 @@ type Entities struct {
 
 type EntityMedia struct {
 	Id                int64      `json:"id"`
-	Id_str            string     `json:"id_str"`
+	IdStr             string     `json:"id_str"`
 	MediaUrl          string     `json:"media_url"`
 	MediaUrlHttps     string     `json:"media_url_https"`
 	Url               string     `json:"url"`

--- a/twitter_entities.go
+++ b/twitter_entities.go
@@ -1,63 +1,59 @@
 package anaconda
 
-type UrlEntity struct {
-	Urls []struct {
-		Indices      []int
-		Url          string
-		Display_url  string
-		Expanded_url string
-	}
+type Hashtags struct {
+	Indices []int  `json:"indices"`
+	Text    string `json:"text"`
+}
+
+type Urls struct {
+	Indices     []int  `json:"indices"`
+	Url         string `json:"url"`
+	DisplayUrl  string `json:"display_url"`
+	ExpandedUrl string `json:"expanded_url"`
+}
+
+type UserMentions struct {
+	Name       string `json:"name"`
+	Indices    []int  `json:"indices"`
+	ScreenName string `json:"screen_name"`
+	Id         int64  `json:"id"`
+	Id_str     string `json:"id_str"`
 }
 
 type Entities struct {
-	Hashtags []struct {
-		Indices []int
-		Text    string
-	}
-	Urls []struct {
-		Indices      []int
-		Url          string
-		Display_url  string
-		Expanded_url string
-	}
-	Url           UrlEntity
-	User_mentions []struct {
-		Name        string
-		Indices     []int
-		Screen_name string
-		Id          int64
-		Id_str      string
-	}
-	Media []EntityMedia
+	Hashtags     []Hashtags     `json:"hashtags"`
+	Urls         []Urls         `json:"urls"`
+	Media        []EntityMedia  `json:"media"`
+	UserMentions []UserMentions `json:"user_mentions"`
 }
 
 type EntityMedia struct {
-	Id                   int64
-	Id_str               string
-	Media_url            string
-	Media_url_https      string
-	Url                  string
-	Display_url          string
-	Expanded_url         string
-	Sizes                MediaSizes
-	Source_status_id     int64
-	Source_status_id_str string
-	Type                 string
-	Indices              []int
-	VideoInfo            VideoInfo `json:"video_info"`
+	Id                int64      `json:"id"`
+	Id_str            string     `json:"id_str"`
+	MediaUrl          string     `json:"media_url"`
+	MediaUrlHttps     string     `json:"media_url_https"`
+	Url               string     `json:"url"`
+	DisplayUrl        string     `json:"display_url"`
+	ExpandedUrl       string     `json:"expanded_url"`
+	Sizes             MediaSizes `json:"sizes"`
+	SourceStatusId    int64      `json:"source_status_id"`
+	SourceStatusIdStr string     `json:"source_status_id_str"`
+	Type              string     `json:"type"`
+	Indices           []int      `json:"indices"`
+	VideoInfo         VideoInfo  `json:"video_info"`
 }
 
 type MediaSizes struct {
-	Medium MediaSize
-	Thumb  MediaSize
-	Small  MediaSize
-	Large  MediaSize
+	Medium MediaSize `json:"medium"`
+	Thumb  MediaSize `json:"thumb"`
+	Small  MediaSize `json:"small"`
+	Large  MediaSize `json:"large"`
 }
 
 type MediaSize struct {
-	W      int
-	H      int
-	Resize string
+	W      int    `json:"w"`
+	H      int    `json:"h"`
+	Resize string `json:"resize"`
 }
 
 type VideoInfo struct {

--- a/twitter_test.go
+++ b/twitter_test.go
@@ -198,46 +198,48 @@ func Test_GetTweet(t *testing.T) {
 	}
 
 	// Check the entities
-	expectedEntities := anaconda.Entities{Hashtags: []struct {
-		Indices []int
-		Text    string
-	}{struct {
-		Indices []int
-		Text    string
-	}{Indices: []int{86, 93}, Text: "golang"}}, Urls: []struct {
-		Indices      []int
-		Url          string
-		Display_url  string
-		Expanded_url string
-	}{}, User_mentions: []struct {
-		Name        string
-		Indices     []int
-		Screen_name string
-		Id          int64
-		Id_str      string
-	}{}, Media: []anaconda.EntityMedia{anaconda.EntityMedia{
-		Id:              303777106628841472,
-		Id_str:          "303777106628841472",
-		Media_url:       "http://pbs.twimg.com/media/BDc7q0OCEAAoe2C.jpg",
-		Media_url_https: "https://pbs.twimg.com/media/BDc7q0OCEAAoe2C.jpg",
-		Url:             "http://t.co/eSq3ROwu",
-		Display_url:     "pic.twitter.com/eSq3ROwu",
-		Expanded_url:    "http://twitter.com/golang/status/303777106620452864/photo/1",
-		Sizes: anaconda.MediaSizes{Medium: anaconda.MediaSize{W: 600,
-			H:      450,
-			Resize: "fit"},
-			Thumb: anaconda.MediaSize{W: 150,
-				H:      150,
-				Resize: "crop"},
-			Small: anaconda.MediaSize{W: 340,
-				H:      255,
-				Resize: "fit"},
-			Large: anaconda.MediaSize{W: 1024,
-				H:      768,
-				Resize: "fit"}},
-		Type: "photo",
-		Indices: []int{94,
-			114}}}}
+	expectedEntities := anaconda.Entities{
+		Hashtags: []anaconda.Hashtags{
+			{
+				Indices: []int{86, 93},
+				Text: "golang",
+			},
+		},
+		Urls: []anaconda.Urls{},
+		UserMentions: []anaconda.UserMentions{},
+		Media: []anaconda.EntityMedia{anaconda.EntityMedia{
+			Id: 303777106628841472,
+			Id_str: "303777106628841472",
+			MediaUrl: "http://pbs.twimg.com/media/BDc7q0OCEAAoe2C.jpg",
+			MediaUrlHttps: "https://pbs.twimg.com/media/BDc7q0OCEAAoe2C.jpg",
+			Url: "http://t.co/eSq3ROwu",
+			DisplayUrl: "pic.twitter.com/eSq3ROwu",
+			ExpandedUrl: "http://twitter.com/golang/status/303777106620452864/photo/1",
+			Sizes: anaconda.MediaSizes{
+				Medium: anaconda.MediaSize{
+					W: 600,
+					H: 450,
+					Resize: "fit",
+				},
+				Thumb: anaconda.MediaSize{
+					W: 150,
+					H: 150,
+					Resize: "crop",
+				},
+				Small: anaconda.MediaSize{
+					W: 340,
+					H: 255,
+					Resize: "fit",
+				},
+				Large: anaconda.MediaSize{
+					W: 1024,
+					H:      768,
+					Resize: "fit",
+				},
+			},
+			Type: "photo",
+			Indices: []int{94, 114},
+		}}}
 	if !reflect.DeepEqual(tweet.Entities, expectedEntities) {
 		t.Fatalf("Tweet entities differ")
 	}

--- a/twitter_test.go
+++ b/twitter_test.go
@@ -202,42 +202,42 @@ func Test_GetTweet(t *testing.T) {
 		Hashtags: []anaconda.Hashtags{
 			{
 				Indices: []int{86, 93},
-				Text: "golang",
+				Text:    "golang",
 			},
 		},
-		Urls: []anaconda.Urls{},
+		Urls:         []anaconda.Urls{},
 		UserMentions: []anaconda.UserMentions{},
 		Media: []anaconda.EntityMedia{anaconda.EntityMedia{
-			Id: 303777106628841472,
-			Id_str: "303777106628841472",
-			MediaUrl: "http://pbs.twimg.com/media/BDc7q0OCEAAoe2C.jpg",
+			Id:            303777106628841472,
+			IdStr:         "303777106628841472",
+			MediaUrl:      "http://pbs.twimg.com/media/BDc7q0OCEAAoe2C.jpg",
 			MediaUrlHttps: "https://pbs.twimg.com/media/BDc7q0OCEAAoe2C.jpg",
-			Url: "http://t.co/eSq3ROwu",
-			DisplayUrl: "pic.twitter.com/eSq3ROwu",
-			ExpandedUrl: "http://twitter.com/golang/status/303777106620452864/photo/1",
+			Url:           "http://t.co/eSq3ROwu",
+			DisplayUrl:    "pic.twitter.com/eSq3ROwu",
+			ExpandedUrl:   "http://twitter.com/golang/status/303777106620452864/photo/1",
 			Sizes: anaconda.MediaSizes{
 				Medium: anaconda.MediaSize{
-					W: 600,
-					H: 450,
+					W:      600,
+					H:      450,
 					Resize: "fit",
 				},
 				Thumb: anaconda.MediaSize{
-					W: 150,
-					H: 150,
+					W:      150,
+					H:      150,
 					Resize: "crop",
 				},
 				Small: anaconda.MediaSize{
-					W: 340,
-					H: 255,
+					W:      340,
+					H:      255,
 					Resize: "fit",
 				},
 				Large: anaconda.MediaSize{
-					W: 1024,
+					W:      1024,
 					H:      768,
 					Resize: "fit",
 				},
 			},
-			Type: "photo",
+			Type:    "photo",
 			Indices: []int{94, 114},
 		}}}
 	if !reflect.DeepEqual(tweet.Entities, expectedEntities) {


### PR DESCRIPTION
Fixes #115 

Also removed ```Url``` property of type ```UrlEntity``` from ```Entities``` struct since it's not mentioned in API docs: https://dev.twitter.com/overview/api/entities-in-twitter-objects#tweets Not sure why it was there, but in official API docs for Tweet Entity only mentions: **media**, **urls**, **user_mentions**, **hashtags** and **symbols**.