### PR TITLE
Add fields to trend structure

### DIFF
--- a/trends.go
+++ b/trends.go
@@ -15,6 +15,8 @@ type Trend struct {
 	Query           string `json:"query"`
 	Url             string `json:"url"`
 	PromotedContent string `json:"promoted_content"`
+	Events          string `json:"events"`
+	TweetVolume     int    `json:"tweet_volume"`
 }
 
 type TrendResponse struct {


### PR DESCRIPTION
Added `events` and `tweet_volume` to the Trend structure.

Reference: GET trends/place
https://dev.twitter.com/rest/reference/get/trends/place