### PR TITLE
Don't set list_id in GetListTweets when listID is zero

### DIFF
--- a/lists.go
+++ b/lists.go
@@ -52,7 +52,9 @@ func (a TwitterApi) GetListTweets(listID int64, includeRTs bool, v url.Values) (
 	if v == nil {
 		v = url.Values{}
 	}
-	v.Set("list_id", strconv.FormatInt(listID, 10))
+	if listID != 0 {
+		v.Set("list_id", strconv.FormatInt(listID, 10))
+	}
 	v.Set("include_rts", strconv.FormatBool(includeRTs))
 
 	response_ch := make(chan response)


### PR DESCRIPTION
Twitter API [lists/statuses](https://dev.twitter.com/rest/reference/get/lists/statuses) requires 'list_id' or 'slug',

I tested GetListTweets with slug and other required parameters, like this below.

```golang
api := anaconda.NewTwitterApi(Token, TokenSecret)
val := url.Values{}
val.Add("owner_screen_name", "foo")
val.Add("slug", "bar")

tweets, err := api.GetListTweets(0, true, val)
// An error occurs!
if err != nil {
	panic(err)
}
			
```

If listID is zero, ignore it and we can use the lists API.
