### PR TITLE
Support for extended mode tweets

### DIFF
--- a/tweet.go
+++ b/tweet.go
@@ -9,12 +9,14 @@ type Tweet struct {
 	Contributors                []int64                `json:"contributors"`
 	Coordinates                 *Coordinates           `json:"coordinates"`
 	CreatedAt                   string                 `json:"created_at"`
+	DisplayTextRange            []int                  `json:"display_text_range"`
 	Entities                    Entities               `json:"entities"`
 	ExtendedEntities            Entities               `json:"extended_entities"`
 	ExtendedTweet               ExtendedTweet          `json:"extended_tweet"`
 	FavoriteCount               int                    `json:"favorite_count"`
 	Favorited                   bool                   `json:"favorited"`
 	FilterLevel                 string                 `json:"filter_level"`
+	FullText                    string                 `json:"full_text"`
 	HasExtendedProfile          bool                   `json:"has_extended_profile"`
 	Id                          int64                  `json:"id"`
 	IdStr                       string                 `json:"id_str"`

--- a/tweet.go
+++ b/tweet.go
@@ -11,6 +11,7 @@ type Tweet struct {
 	CreatedAt                   string                 `json:"created_at"`
 	Entities                    Entities               `json:"entities"`
 	ExtendedEntities            Entities               `json:"extended_entities"`
+	ExtendedTweet               ExtendedTweet          `json:"extended_tweet"`
 	FavoriteCount               int                    `json:"favorite_count"`
 	Favorited                   bool                   `json:"favorited"`
 	FilterLevel                 string                 `json:"filter_level"`
@@ -44,6 +45,13 @@ type Tweet struct {
 
 	//Geo is deprecated
 	//Geo                  interface{} `json:"geo"`
+}
+
+type ExtendedTweet struct {
+	FullText         string   `json:"full_text"`
+	DisplayTextRange []int    `json:"display_text_range"`
+	Entities         Entities `json:"entities"`
+	ExtendedEntities Entities `json:"extended_entities"`
 }
 
 // CreatedAtTime is a convenience wrapper that returns the Created_at time, parsed as a time.Time struct


### PR DESCRIPTION
Hello and greetings!

Per Twitter*, tweets are now being provided in an extended format. This PR adds some changes to allow Streaming and REST API users to process extended mode tweets.

REST API users will need to add an extra `url.Values{}` parameter** to access this mode, while Streaming users are provided an extra struct: "ExtendedTweet", which is populated with extended tweet information.

Please feel free to add suggestions, or to close this PR as needed.

cheers

\* https://dev.twitter.com/overview/api/upcoming-changes-to-tweets
** `v.Set("tweet_mode", "extended")`
