### PR TITLE
Add ext_alt_text

### DIFF
--- a/twitter_entities.go
+++ b/twitter_entities.go
@@ -45,6 +45,7 @@ type EntityMedia struct {
 	Type                 string
 	Indices              []int
 	VideoInfo            VideoInfo `json:"video_info"`
+	ExtAltText           string    `json:"ext_alt_text"`
 }
 
 type MediaSizes struct {


### PR DESCRIPTION
I added a parameter named 'ext_alt_text' to `EntityMedia`. It contains the description of a media if a user set it.
The parameter was introduced by [the post](https://blog.twitter.com/2016/alt-text-support-for-twitter-cards-and-the-rest-api).

*Note
The post says api returns `ext_alt_text` by default, but we need `include_ext_alt_text=true` query parameter yet.