### PR TITLE
TwitterApi.throttledQuery goroutine bugfix

### DIFF
--- a/twitter.go
+++ b/twitter.go
@@ -314,9 +314,9 @@ func (c *TwitterApi) throttledQuery() {
 
 					// If this is a rate-limiting error, re-add the job to the queue
 					// TODO it really should preserve order
-					go func() {
+					go func(q query) {
 						c.queryQueue <- q
-					}()
+					}(q)
 
 					delay := nextWindow.Sub(time.Now())
 					<-time.After(delay)


### PR DESCRIPTION
as it stands, 'q' can change value before the goroutine is evaluated, resulting in the wrong entry being returned to the queue.

The sleep that follows probably makes it virtually impossible to occur, but should still be fixed.