### PR TITLE
Configure AppVeyor for Windows CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,8 @@
+clone_folder: c:\gopath\src\github.com\ChimeraCoder\anaconda
+
+environment:
+    GOPATH: c:\gopath
+
+build_script:
+    - go get .
+    - go test -v

--- a/twitter_test.go
+++ b/twitter_test.go
@@ -87,7 +87,7 @@ func init() {
 			defer f.Close()
 
 			// TODO not a hack
-			if sourceFilename == "json/statuses/show.json_id_404409873170841600" {
+			if sourceFilename == filepath.Join("json", "statuses", "show.json_id_404409873170841600") {
 				bts, err := ioutil.ReadAll(f)
 				if err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Now that https://github.com/ChimeraCoder/anaconda/pull/174 is merged, we can enable CI on Windows.