### PR TITLE
Fixed formatting of Error Handling subheaders in README

### DIFF
--- a/README
+++ b/README
@@ -57,7 +57,7 @@ In a few cases, a shortened form has been chosen to make life easier (for exampl
 Error Handling, Rate Limiting, and Throttling
 ---------------------------------
 
-###Error Handling
+### Error Handling
 
 Twitter errors are returned as an `ApiError`, which satisfies the `error` interface and can be treated as a vanilla `error`. However, it also contains the additional information returned by the Twitter API that may be useful in deciding how to proceed after encountering an error.
 
@@ -70,7 +70,7 @@ In other words, users of the `anaconda` library should not need to handle rate l
 (If desired, this feature can be turned off by calling `ReturnRateLimitError(true)`.)
 
 
-###Throttling
+### Throttling
 
 Anaconda now supports automatic client-side throttling of queries to avoid hitting the Twitter rate-limit.
 
@@ -92,7 +92,7 @@ To turn off automatic throttling, set the delay to `0`:
     api.SetDelay(0 * time.Second)
 ````
 
-###Query Queue Persistence
+### Query Queue Persistence
 
 If your code creates a NewTwitterApi in a regularly called function, you'll need to call `.Close()` on the API struct to clear the queryQueue and allow the goroutine to exit. Otherwise you could see goroutine and therefor heap memory leaks in long-running applications.
 


### PR DESCRIPTION
Spaces were missing between the ### and the actual subheading title.