### PR TITLE
Fix wrong return type of get direct message show function

### DIFF
--- a/directmessages.go
+++ b/directmessages.go
@@ -17,10 +17,10 @@ func (a TwitterApi) GetDirectMessagesSent(v url.Values) (messages []DirectMessag
 	return messages, (<-response_ch).err
 }
 
-func (a TwitterApi) GetDirectMessagesShow(v url.Values) (messages []DirectMessage, err error) {
+func (a TwitterApi) GetDirectMessagesShow(v url.Values) (message DirectMessage, err error) {
 	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/direct_messages/show.json", v, &messages, _GET, response_ch}
-	return messages, (<-response_ch).err
+	a.queryQueue <- query{a.baseUrl + "/direct_messages/show.json", v, &message, _GET, response_ch}
+	return message, (<-response_ch).err
 }
 
 // https://dev.twitter.com/docs/api/1.1/post/direct_messages/new


### PR DESCRIPTION
I found an error when I use function `GetDirectMessagesShow`
My code is `api.GetDirectMessagesShow(url.Values{"id": []string{direct_message_id})`.
An error message is
> json: cannot unmarshal object into Go value of type []anaconda.DirectMessage

According to twitter api document https://dev.twitter.com/rest/reference/get/direct_messages/show.
It returns a single direct message, specified by an id parameter.
It's example response shows there is a direct message in an array as show below.
`[
    {
        "created_at": "Mon Aug 27 17:21:03 +0000 2012","..."
    }
]
`
But when I use api via twitter api console, it returns only a direct message, not in an array.
It should return `DirectMessage`, not `[]DirectMessage`.
Then I change the return data type from `[]DirectMessage` to `DirectMessage`, it returns data without an error.
