### PR TITLE
Fix https://github.com/ChimeraCoder/anaconda/issues/101

### DIFF
--- a/README
+++ b/README
@@ -17,9 +17,7 @@ Examples
 If you already have the access token (and secret) for your user (Twitter provides this for your own account on the developer portal), creating the client is simple:
 
 ````go
-anaconda.SetConsumerKey("your-consumer-key")
-anaconda.SetConsumerSecret("your-consumer-secret")
-api := anaconda.NewTwitterApi("your-access-token", "your-access-token-secret")
+api := anaconda.NewTwitterApi("your-access-token", "your-access-token-secret", "your-consumer-key", "your-consumer-secret")
 ````
 
 ### Queries

--- a/example_test.go
+++ b/example_test.go
@@ -10,17 +10,12 @@ import (
 // Initialize an client library for a given user.
 // This only needs to be done *once* per user
 func ExampleTwitterApi_InitializeClient() {
-	anaconda.SetConsumerKey("your-consumer-key")
-	anaconda.SetConsumerSecret("your-consumer-secret")
-	api := anaconda.NewTwitterApi(ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
+	api := anaconda.NewTwitterApi(ACCESS_TOKEN, ACCESS_TOKEN_SECRET, "your-consumer-key", "your-consumer-secret")
 	fmt.Println(*api.Credentials)
 }
 
 func ExampleTwitterApi_GetSearch() {
-
-	anaconda.SetConsumerKey("your-consumer-key")
-	anaconda.SetConsumerSecret("your-consumer-secret")
-	api := anaconda.NewTwitterApi("your-access-token", "your-access-token-secret")
+	api := anaconda.NewTwitterApi("your-access-token", "your-access-token-secret", "your-consumer-key", "your-consumer-secret")
 	search_result, err := api.GetSearch("golang", nil)
 	if err != nil {
 		panic(err)
@@ -32,7 +27,7 @@ func ExampleTwitterApi_GetSearch() {
 
 // Throttling queries can easily be handled in the background, automatically
 func ExampleTwitterApi_Throttling() {
-	api := anaconda.NewTwitterApi("your-access-token", "your-access-token-secret")
+	api := anaconda.NewTwitterApi("your-access-token", "your-access-token-secret", "your-consumer-key", "your-consumer-secret")
 	api.EnableThrottling(10*time.Second, 5)
 
 	// These queries will execute in order

--- a/oembed_test.go
+++ b/oembed_test.go
@@ -11,7 +11,7 @@ import (
 func TestOEmbed(t *testing.T) {
 	// It is the only one that can be tested without auth
 	// However, it is still rate-limited
-	api := anaconda.NewTwitterApi("", "")
+	api := anaconda.NewTwitterApi("", "", "", "")
 	api.SetBaseUrl(testBase)
 	o, err := api.GetOEmbed(url.Values{"id": []string{"99530515043983360"}})
 	if err != nil {

--- a/streaming.go
+++ b/streaming.go
@@ -203,9 +203,9 @@ func jsonToKnownType(j []byte) interface{} {
 func (s *Stream) requestStream(urlStr string, v url.Values, method int) (resp *http.Response, err error) {
 	switch method {
 	case _GET:
-		return oauthClient.Get(s.api.HttpClient, s.api.Credentials, urlStr, v)
+		return s.api.oauthClient.Get(s.api.HttpClient, s.api.Credentials, urlStr, v)
 	case _POST:
-		return oauthClient.Post(s.api.HttpClient, s.api.Credentials, urlStr, v)
+		return s.api.oauthClient.Post(s.api.HttpClient, s.api.Credentials, urlStr, v)
 	default:
 	}
 	return nil, fmt.Errorf("HTTP method not yet supported")

--- a/twitter_test.go
+++ b/twitter_test.go
@@ -30,9 +30,7 @@ var testBase string
 
 func init() {
 	// Initialize api so it can be used even when invidual tests are run in isolation
-	anaconda.SetConsumerKey(CONSUMER_KEY)
-	anaconda.SetConsumerSecret(CONSUMER_SECRET)
-	api = anaconda.NewTwitterApi(ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
+	api = anaconda.NewTwitterApi(ACCESS_TOKEN, ACCESS_TOKEN_SECRET, CONSUMER_KEY, CONSUMER_SECRET)
 
 	if CONSUMER_KEY != "" && CONSUMER_SECRET != "" && ACCESS_TOKEN != "" && ACCESS_TOKEN_SECRET != "" {
 		return
@@ -115,9 +113,7 @@ func Test_TwitterCredentials(t *testing.T) {
 
 // Test that creating a TwitterApi client creates a client with non-empty OAuth credentials
 func Test_TwitterApi_NewTwitterApi(t *testing.T) {
-	anaconda.SetConsumerKey(CONSUMER_KEY)
-	anaconda.SetConsumerSecret(CONSUMER_SECRET)
-	apiLocal := anaconda.NewTwitterApi(ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
+	apiLocal := anaconda.NewTwitterApi(ACCESS_TOKEN, ACCESS_TOKEN_SECRET, CONSUMER_KEY, CONSUMER_SECRET)
 
 	if apiLocal.Credentials == nil {
 		t.Fatalf("Twitter Api client has empty (nil) credentials")


### PR DESCRIPTION
I moved the `oauthClient` variable within the `TwitterAPI` structure and I changed every method that used the `oauthClient` variable to use the new one, within the structure.

In this way, we can spawn multiple thread-safe applications.
In short: fix #101 