### PR TITLE
Implement unretweet support which return back the status normal tweet.

### DIFF
--- a/tweets.go
+++ b/tweets.go
@@ -69,6 +69,22 @@ func (a TwitterApi) Retweet(id int64, trimUser bool) (rt Tweet, err error) {
 	return rt, (<-response_ch).err
 }
 
+//UnRetweet will renove retweet Untweets a retweeted status.
+//Returns the original Tweet with retweet details embedded.
+//
+//https://dev.twitter.com/rest/reference/post/statuses/unretweet/id
+//trim_user: tweet returned in a timeline will include a user object
+//including only the status authors numerical ID.
+func (a TwitterApi) UnRetweet(id int64, trimUser bool) (rt Tweet, err error) {
+	v := url.Values{}
+	if trimUser {
+		v.Set("trim_user", "t")
+	}
+	response_ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + fmt.Sprintf("/statuses/unretweet/%d.json", id), v, &rt, _POST, response_ch}
+	return rt, (<-response_ch).err
+}
+
 // Favorite will favorite the status (tweet) with the specified ID.
 // https://dev.twitter.com/docs/api/1.1/post/favorites/create
 func (a TwitterApi) Favorite(id int64) (rt Tweet, err error) {

--- a/twitter.go
+++ b/twitter.go
@@ -55,6 +55,8 @@ import (
 const (
 	_GET          = iota
 	_POST         = iota
+	_DELETE       = iota
+	_PUT          = iota
 	BaseUrlV1     = "https://api.twitter.com/1"
 	BaseUrl       = "https://api.twitter.com/1.1"
 	UploadBaseUrl = "https://upload.twitter.com/1.1"
@@ -207,6 +209,26 @@ func (c TwitterApi) apiPost(urlStr string, form url.Values, data interface{}) er
 	return decodeResponse(resp, data)
 }
 
+// apiDel issues a DELETE request to the Twitter API and decodes the response JSON to data.
+func (c TwitterApi) apiDel(urlStr string, form url.Values, data interface{}) error {
+	resp, err := oauthClient.Delete(c.HttpClient, c.Credentials, urlStr, form)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return decodeResponse(resp, data)
+}
+
+// apiPut issues a PUT request to the Twitter API and decodes the response JSON to data.
+func (c TwitterApi) apiPut(urlStr string, form url.Values, data interface{}) error {
+	resp, err := oauthClient.Put(c.HttpClient, c.Credentials, urlStr, form)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return decodeResponse(resp, data)
+}
+
 // decodeResponse decodes the JSON response from the Twitter API.
 func decodeResponse(resp *http.Response, data interface{}) error {
 	// according to dev.twitter.com, chunked upload append returns HTTP 2XX
@@ -243,6 +265,10 @@ func (c TwitterApi) execQuery(urlStr string, form url.Values, data interface{}, 
 	case _GET:
 		return c.apiGet(urlStr, form, data)
 	case _POST:
+		return c.apiPost(urlStr, form, data)
+	case _DELETE:
+		return c.apiPost(urlStr, form, data)
+	case _PUT:
 		return c.apiPost(urlStr, form, data)
 	default:
 		return fmt.Errorf("HTTP method not yet supported")

--- a/webhook.go
+++ b/webhook.go
@@ -38,48 +38,48 @@ func (a TwitterApi) SetActivityWebhooks(v url.Values) (u []WebHookResp, err erro
 
 //DeleteActivityWebhooks Removes the webhook from the provided application’s configuration.
 //https://dev.twitter.com/webhooks/reference/del/account_activity/webhooks
-func (a TwitterApi) DeleteActivityWebhooks(v url.Values) (u interface{}, err error) {
+func (a TwitterApi) DeleteActivityWebhooks(v url.Values, webhookID string) (u interface{}, err error) {
 	v = cleanValues(v)
 	responseCh := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/:webhook_id.json", v, &u, _DELETE, responseCh}
+	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + ".json", v, &u, _DELETE, responseCh}
 	return u, (<-responseCh).err
 }
 
 //PutActivityWebhooks update webhook which reenables the webhook by setting its status to valid.
 //https://dev.twitter.com/webhooks/reference/put/account_activity/webhooks
-func (a TwitterApi) PutActivityWebhooks(v url.Values) (u interface{}, err error) {
+func (a TwitterApi) PutActivityWebhooks(v url.Values, webhookID string) (u interface{}, err error) {
 	v = cleanValues(v)
 	responseCh := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/:webhook_id.json", v, &u, _PUT, responseCh}
+	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + ".json", v, &u, _PUT, responseCh}
 	return u, (<-responseCh).err
 }
 
 //SetWHSubscription Subscribes the provided app to events for the provided user context.
 //When subscribed, all DM events for the provided user will be sent to the app’s webhook via POST request.
 //https://dev.twitter.com/webhooks/reference/post/account_activity/webhooks/subscriptions
-func (a TwitterApi) SetWHSubscription(v url.Values) (u interface{}, err error) {
+func (a TwitterApi) SetWHSubscription(v url.Values, webhookID string) (u interface{}, err error) {
 	v = cleanValues(v)
 	responseCh := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/:webhook_id/subscriptions.json", v, &u, _POST, responseCh}
+	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + "/subscriptions.json", v, &u, _POST, responseCh}
 	return u, (<-responseCh).err
 }
 
 //GetWHSubscription Provides a way to determine if a webhook configuration is
 //subscribed to the provided user’s Direct Messages.
 //https://dev.twitter.com/webhooks/reference/get/account_activity/webhooks/subscriptions
-func (a TwitterApi) GetWHSubscription(v url.Values) (u interface{}, err error) {
+func (a TwitterApi) GetWHSubscription(v url.Values, webhookID string) (u interface{}, err error) {
 	v = cleanValues(v)
 	responseCh := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/:webhook_id/subscriptions.json", v, &u, _GET, responseCh}
+	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + "/subscriptions.json", v, &u, _GET, responseCh}
 	return u, (<-responseCh).err
 }
 
 //DeleteWHSubscription Deactivates subscription for the provided user context and app. After deactivation,
 //all DM events for the requesting user will no longer be sent to the webhook URL..
 //https://dev.twitter.com/webhooks/reference/del/account_activity/webhooks
-func (a TwitterApi) DeleteWHSubscription(v url.Values) (u interface{}, err error) {
+func (a TwitterApi) DeleteWHSubscription(v url.Values, webhookID string) (u interface{}, err error) {
 	v = cleanValues(v)
 	responseCh := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/:webhook_id/subscriptions.json", v, &u, _DELETE, responseCh}
+	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + "/subscriptions.json", v, &u, _DELETE, responseCh}
 	return u, (<-responseCh).err
 }

--- a/webhook.go
+++ b/webhook.go
@@ -1,0 +1,85 @@
+package anaconda
+
+import (
+	"net/url"
+)
+
+//GetActivityWebhooks represents the twitter account_activity webhook
+//Returns all URLs and their statuses for the given app. Currently,
+//only one webhook URL can be registered to an application.
+//https://dev.twitter.com/webhooks/reference/get/account_activity/webhooks
+func (a TwitterApi) GetActivityWebhooks(v url.Values) (u []WebHookResp, err error) {
+	v = cleanValues(v)
+	responseCh := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks.json", v, &u, _GET, responseCh}
+	return u, (<-responseCh).err
+}
+
+//WebHookResp represents the Get webhook responses
+type WebHookResp struct {
+	ID        string
+	URL       string
+	Valid     bool
+	CreatedAt string
+}
+
+//SetActivityWebhooks represents to set twitter account_activity webhook
+//Registers a new webhook URL for the given application context.
+//The URL will be validated via CRC request before saving. In case the validation fails,
+//a comprehensive error is returned. message to the requester.
+//Only one webhook URL can be registered to an application.
+//https://api.twitter.com/1.1/account_activity/webhooks.json
+func (a TwitterApi) SetActivityWebhooks(v url.Values) (u []WebHookResp, err error) {
+	v = cleanValues(v)
+	responseCh := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks.json", v, &u, _POST, responseCh}
+	return u, (<-responseCh).err
+}
+
+//DeleteActivityWebhooks Removes the webhook from the provided application’s configuration.
+//https://dev.twitter.com/webhooks/reference/del/account_activity/webhooks
+func (a TwitterApi) DeleteActivityWebhooks(v url.Values) (u interface{}, err error) {
+	v = cleanValues(v)
+	responseCh := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/:webhook_id.json", v, &u, _DELETE, responseCh}
+	return u, (<-responseCh).err
+}
+
+//PutActivityWebhooks update webhook which reenables the webhook by setting its status to valid.
+//https://dev.twitter.com/webhooks/reference/put/account_activity/webhooks
+func (a TwitterApi) PutActivityWebhooks(v url.Values) (u interface{}, err error) {
+	v = cleanValues(v)
+	responseCh := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/:webhook_id.json", v, &u, _PUT, responseCh}
+	return u, (<-responseCh).err
+}
+
+//SetWHSubscription Subscribes the provided app to events for the provided user context.
+//When subscribed, all DM events for the provided user will be sent to the app’s webhook via POST request.
+//https://dev.twitter.com/webhooks/reference/post/account_activity/webhooks/subscriptions
+func (a TwitterApi) SetWHSubscription(v url.Values) (u interface{}, err error) {
+	v = cleanValues(v)
+	responseCh := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/:webhook_id/subscriptions.json", v, &u, _POST, responseCh}
+	return u, (<-responseCh).err
+}
+
+//GetWHSubscription Provides a way to determine if a webhook configuration is
+//subscribed to the provided user’s Direct Messages.
+//https://dev.twitter.com/webhooks/reference/get/account_activity/webhooks/subscriptions
+func (a TwitterApi) GetWHSubscription(v url.Values) (u interface{}, err error) {
+	v = cleanValues(v)
+	responseCh := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/:webhook_id/subscriptions.json", v, &u, _GET, responseCh}
+	return u, (<-responseCh).err
+}
+
+//DeleteWHSubscription Deactivates subscription for the provided user context and app. After deactivation,
+//all DM events for the requesting user will no longer be sent to the webhook URL..
+//https://dev.twitter.com/webhooks/reference/del/account_activity/webhooks
+func (a TwitterApi) DeleteWHSubscription(v url.Values) (u interface{}, err error) {
+	v = cleanValues(v)
+	responseCh := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/:webhook_id/subscriptions.json", v, &u, _DELETE, responseCh}
+	return u, (<-responseCh).err
+}


### PR DESCRIPTION
please add this to anaconda to support `unretweet`
Ref: https://dev.twitter.com/rest/reference/post/statuses/unretweet/id