### PR TITLE
Tiny typo fix in streaming.go

### DIFF
--- a/streaming.go
+++ b/streaming.go
@@ -151,7 +151,7 @@ func (s *Stream) listen(response http.Response) {
 		defer response.Body.Close()
 	}
 
-	s.api.Log.Notice("Listenning to twitter socket")
+	s.api.Log.Notice("Listening to twitter socket")
 	defer s.api.Log.Notice("twitter socket closed, leaving loop")
 
 	scanner := bufio.NewScanner(response.Body)


### PR DESCRIPTION
I noticed while using the library that it logged "Listenning" with 2 `n`s.