### PR TITLE
add field FullText to Tweet

### DIFF
--- a/tweet.go
+++ b/tweet.go
@@ -36,6 +36,7 @@ type Tweet struct {
 	Source                      string                 `json:"source"`
 	Scopes                      map[string]interface{} `json:"scopes"`
 	Text                        string                 `json:"text"`
+	FullText                    string                 `json:"full_text"`
 	Truncated                   bool                   `json:"truncated"`
 	User                        User                   `json:"user"`
 	WithheldCopyright           bool                   `json:"withheld_copyright"`


### PR DESCRIPTION
when the tweet_mode is set to "extended", twitter API responds with the field
"full_text" instead of text. text is omitted, unless tweet_mode is set to
"compatibility".
So in order to get the text at all in "extended mode", we need this field.
Please refer to https://dev.twitter.com/overview/api/upcoming-changes-to-tweets.

edit: please correct me if i got something wrong, i am not an expert concerning the twitter API.