### PR TITLE
Fixes memory leak in decodeResponse()

### DIFF
--- a/twitter.go
+++ b/twitter.go
@@ -231,6 +231,10 @@ func (c TwitterApi) apiPut(urlStr string, form url.Values, data interface{}) err
 
 // decodeResponse decodes the JSON response from the Twitter API.
 func decodeResponse(resp *http.Response, data interface{}) error {
+	// Prevent memory leak in the case where the Response.Body is not used.
+	// As per the net/http package, Response.Body still needs to be closed.
+	defer resp.Body.Close()
+
 	// according to dev.twitter.com, chunked upload append returns HTTP 2XX
 	// so we need a special case when decoding the response
 	if strings.HasSuffix(resp.Request.URL.String(), "upload.json") {


### PR DESCRIPTION
The function `decodeResponse()` in twitter.go did not close the response body in all circumstances. Closure of Response.Body is required as per net/http, even when the body is not used.

On my long-running server-side app, this led to infinite memory growth over time.