### PR TITLE
Add gofmt check to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,15 @@ os:
   - linux
   - osx
 
+before_script:
+  - gofmt -w .
+
+  # If `go generate` or `gofmt` yielded any changes,
+  # this will fail with an error message like "too many arguments"
+  # or "M: binary operator expected"
+  - git add .
+  - git diff-index --cached --exit-code HEAD
+
 go:
   - 1.6
   - 1.7

--- a/vendor/github.com/ChimeraCoder/tokenbucket/tokenbucket.go
+++ b/vendor/github.com/ChimeraCoder/tokenbucket/tokenbucket.go
@@ -73,14 +73,14 @@ func (b *Bucket) SpendToken(n int64) <-chan error {
 // Drain will empty all tokens in the bucket
 // If the tokens are being added too quickly (if the rate is too fast)
 // this will never drain
-func (b *Bucket) Drain() error{
-    // TODO replace this with a more solid approach (such as replacing the channel altogether)
-    for {
-        select {
-            case _ = <-b.tokens:
-                continue
-            default:
-                return nil
-        }
-    }
+func (b *Bucket) Drain() error {
+	// TODO replace this with a more solid approach (such as replacing the channel altogether)
+	for {
+		select {
+		case _ = <-b.tokens:
+			continue
+		default:
+			return nil
+		}
+	}
 }

--- a/vendor/github.com/dustin/gojson/decode_test.go
+++ b/vendor/github.com/dustin/gojson/decode_test.go
@@ -1385,7 +1385,7 @@ func TestValidator(t *testing.T) {
 		err := Validate([]byte(tt.in))
 		if (expectederr == nil) != (err == nil) {
 			t.Errorf("Incorrectly validated %v - %v/%v",
-			tt.in, expectederr, err)
+				tt.in, expectederr, err)
 		}
 	}
 }


### PR DESCRIPTION
Ensure that unformatted code causes CI build to fail.

The first test failure is intentional, since some of the code isn't formatted to 1.9 standards.