### PR TITLE
Specify gofmt version for build check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ before_script:
 
   # If `go generate` or `gofmt` yielded any changes,
   # this will fail with an error message like "too many arguments"
-  # or "M: binary operator expected"
+  # or "M: binary operator expected" and show the diff.
+  - git diff
   - git add .
   - git diff-index --cached --exit-code HEAD
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ os:
   - linux
   - osx
 
+install:
+  # Use gofmt from Go 1.9 for the pre-build check on all builds
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then wget -O go.tar.gz https://storage.googleapis.com/golang/go1.9.darwin-amd64.tar.gz; else wget -O go.tar.gz https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz; fi
+  - tar -C /tmp -xvf go.tar.gz go/bin/gofmt
+  - sudo mv /tmp/go/bin/gofmt /usr/bin/gofmt
+  - rm go.tar.gz
+
 before_script:
   - gofmt -w .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,5 @@ go:
   - tip
 
 script:
-    - go test -race -v -timeout 120s ./...
+  - echo $TRAVIS_GO_VERSION
+  - if [ "$TRAVIS_GO_VERSION" == "1.6" ] || [ "$TRAVIS_GO_VERSION" == "1.7" ] || [ "$TRAVIS_GO_VERSION" == "1.8" ]; then go list ./... | grep -v vendor | xargs go test -race -v -timeout 60s; else go test -race -v -timeout 60s ./...; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   # Use gofmt from Go 1.9 for the pre-build check on all builds
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then wget -O go.tar.gz https://storage.googleapis.com/golang/go1.9.darwin-amd64.tar.gz; else wget -O go.tar.gz https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz; fi
   - tar -C /tmp -xvf go.tar.gz go/bin/gofmt
+  - rm go.tar.gz
 
 before_script:
   - /tmp/go/bin/gofmt -w .

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,9 @@ install:
   # Use gofmt from Go 1.9 for the pre-build check on all builds
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then wget -O go.tar.gz https://storage.googleapis.com/golang/go1.9.darwin-amd64.tar.gz; else wget -O go.tar.gz https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz; fi
   - tar -C /tmp -xvf go.tar.gz go/bin/gofmt
-  - sudo mv /tmp/go/bin/gofmt /usr/bin/gofmt
-  - rm go.tar.gz
 
 before_script:
-  - gofmt -w .
+  - /tmp/go/bin/gofmt -w .
 
   # If `go generate` or `gofmt` yielded any changes,
   # this will fail with an error message like "too many arguments"

--- a/twitter_test.go
+++ b/twitter_test.go
@@ -388,6 +388,18 @@ func Test_TwitterApi_TwitterErrorDoesNotExist(t *testing.T) {
 	}
 }
 
+func Test_DMScreenName(t *testing.T) {
+	to, err := api.GetSelf(url.Values{})
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = api.PostDMToScreenName("Test the anaconda lib", to.ScreenName)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}
+
 // Test that the client can be used to throttle to an arbitrary duration
 func Test_TwitterApi_Throttling(t *testing.T) {
 	const MIN_DELAY = 15 * time.Second
@@ -413,16 +425,4 @@ func Test_TwitterApi_Throttling(t *testing.T) {
 
 	// Reset the delay to its previous value
 	api.SetDelay(oldDelay)
-}
-
-func Test_DMScreenName(t *testing.T) {
-	to, err := api.GetSelf(url.Values{})
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = api.PostDMToScreenName("Test the anaconda lib", to.ScreenName)
-	if err != nil {
-		t.Error(err)
-		return
-	}
 }

--- a/twitter_test.go
+++ b/twitter_test.go
@@ -272,7 +272,7 @@ func Test_GetQuotedTweet(t *testing.T) {
 	}
 
 	if tweet.QuotedStatus.Text != quotedText {
-		t.Fatalf("Expected quoted status text %#v, received $#v", quotedText, tweet.QuotedStatus.Text)
+		t.Fatalf("Expected quoted status text %#v, received %#v", quotedText, tweet.QuotedStatus.Text)
 	}
 }
 


### PR DESCRIPTION
Gofmt can change (and in particular, changes may be introduced on tip), so we need to specify the version that's used for the build check step.