### PR TITLE
Fix follow event return data type not unmarshalled properly

### DIFF
--- a/streaming.go
+++ b/streaming.go
@@ -122,6 +122,10 @@ type EventTweet struct {
 	TargetObject *Tweet `json:"target_object"`
 }
 
+type EventFollow struct {
+	Event
+}
+
 type TooManyFollow struct {
 	Warning *struct {
 		Code    string `json:"code"`
@@ -208,6 +212,8 @@ func jsonToKnownType(j []byte) interface{} {
 	} else if o := new(EventList); jsonAsStruct(j, "/target_object/slug", &o) {
 		return *o
 	} else if o := new(Event); jsonAsStruct(j, "/target_object", &o) {
+		return *o
+	} else if o := new(EventFollow); jsonAsStruct(j, "/event", &o) {
 		return *o
 	} else {
 		return nil


### PR DESCRIPTION
If someone click on `following` button then api returns only `Event`
object, but since there is `target_object` has used to unmarshall to
struct. So I add EventFollow which is a mimic of Event.

I've to handle the `Event` follow so I added it. Please add to upstream. 
Thanks