### PR TITLE
implement /lists/members.json with pagination resolving

### DIFF
--- a/list.go
+++ b/list.go
@@ -1,9 +1,18 @@
 package anaconda
 
+type NextPrevCursor struct {
+	PreviousCursor int `json:"previous_cursor"`
+	NextCursor     int `json:"next_cursor"`
+}
+
 type ListResponse struct {
-	PreviousCursor int    `json:"previous_cursor"`
-	NextCursor     int    `json:"next_cursor"`
-	Lists          []List `json:"lists"`
+	NextPrevCursor
+	Lists []List `json:"lists"`
+}
+
+type ListMembershipResponse struct {
+	NextPrevCursor
+	Users []User `json:"users"`
 }
 
 type AddUserToListResponse struct {


### PR DESCRIPTION
Hi,

here is an implementation of [/lists/members.json](https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members.html). I decided to directly implement cursoring but would make that optional if wanted.