### PR TITLE
Decouple TwitterApi from global oauthClient

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,7 @@ Anaconda
 
 [![Build Status](https://travis-ci.org/ChimeraCoder/anaconda.svg?branch=master)](https://travis-ci.org/ChimeraCoder/anaconda) [![Build Status](https://ci.appveyor.com/api/projects/status/63pi6csod8bps80i/branch/master?svg=true)](https://ci.appveyor.com/project/ChimeraCoder/anaconda/branch/master) [![GoDoc](https://godoc.org/github.com/ChimeraCoder/anaconda?status.svg)](https://godoc.org/github.com/ChimeraCoder/anaconda)
 
-Anaconda is a simple, transparent Go package for accessing version 1.1 of the Twitter API. 
+Anaconda is a simple, transparent Go package for accessing version 1.1 of the Twitter API.
 
 Successful API queries return native Go structs that can be used immediately, with no need for type assertions.
 
@@ -17,9 +17,7 @@ Examples
 If you already have the access token (and secret) for your user (Twitter provides this for your own account on the developer portal), creating the client is simple:
 
 ````go
-anaconda.SetConsumerKey("your-consumer-key")
-anaconda.SetConsumerSecret("your-consumer-secret")
-api := anaconda.NewTwitterApi("your-access-token", "your-access-token-secret")
+api := anaconda.NewTwitterApiWithCredentials("your-access-token", "your-access-token-secret", "your-consumer-key", "your-consumer-secret")
 ````
 
 ### Queries
@@ -30,9 +28,9 @@ Queries are conducted using a pointer to an authenticated `TwitterApi` struct. I
 searchResult, _ := api.GetSearch("golang", nil)
 for _ , tweet := range searchResult.Statuses {
     fmt.Println(tweet.Text)
-}   
+}
 ````
-Certain endpoints allow separate optional parameter; if desired, these can be passed as the final parameter. 
+Certain endpoints allow separate optional parameter; if desired, these can be passed as the final parameter.
 
 ````go
 //Perhaps we want 30 values instead of the default 15

--- a/example_test.go
+++ b/example_test.go
@@ -10,14 +10,11 @@ import (
 // Initialize an client library for a given user.
 // This only needs to be done *once* per user
 func ExampleTwitterApi_InitializeClient() {
-	anaconda.SetConsumerKey("your-consumer-key")
-	anaconda.SetConsumerSecret("your-consumer-secret")
-	api := anaconda.NewTwitterApi(ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
+	api := anaconda.NewTwitterApiWithCredentials(ACCESS_TOKEN, ACCESS_TOKEN_SECRET, "your-consumer-key", "your-consumer-secret")
 	fmt.Println(*api.Credentials)
 }
 
 func ExampleTwitterApi_GetSearch() {
-
 	anaconda.SetConsumerKey("your-consumer-key")
 	anaconda.SetConsumerSecret("your-consumer-secret")
 	api := anaconda.NewTwitterApi("your-access-token", "your-access-token-secret")

--- a/streaming.go
+++ b/streaming.go
@@ -217,9 +217,9 @@ func jsonToKnownType(j []byte) interface{} {
 func (s *Stream) requestStream(urlStr string, v url.Values, method int) (resp *http.Response, err error) {
 	switch method {
 	case _GET:
-		return oauthClient.Get(s.api.HttpClient, s.api.Credentials, urlStr, v)
+		return s.api.oauthClient.Get(s.api.HttpClient, s.api.Credentials, urlStr, v)
 	case _POST:
-		return oauthClient.Post(s.api.HttpClient, s.api.Credentials, urlStr, v)
+		return s.api.oauthClient.Post(s.api.HttpClient, s.api.Credentials, urlStr, v)
 	default:
 	}
 	return nil, fmt.Errorf("HTTP method not yet supported")

--- a/twitter.go
+++ b/twitter.go
@@ -63,11 +63,9 @@ const (
 	UploadBaseUrl = "https://upload.twitter.com/1.1"
 )
 
-var oauthClient = oauth.Client{
-	TemporaryCredentialRequestURI: "https://api.twitter.com/oauth/request_token",
-	ResourceOwnerAuthorizationURI: "https://api.twitter.com/oauth/authenticate",
-	TokenRequestURI:               "https://api.twitter.com/oauth/access_token",
-}
+var (
+	oauthCredentials oauth.Credentials
+)
 
 type TwitterApi struct {
 	oauthClient          oauth.Client
@@ -110,7 +108,12 @@ func NewTwitterApi(access_token string, access_token_secret string) *TwitterApi 
 	//A non-buffered channel will cause blocking when multiple queries are made at the same time
 	queue := make(chan query)
 	c := &TwitterApi{
-		oauthClient: oauthClient,
+		oauthClient: oauth.Client{
+			TemporaryCredentialRequestURI: "https://api.twitter.com/oauth/request_token",
+			ResourceOwnerAuthorizationURI: "https://api.twitter.com/oauth/authenticate",
+			TokenRequestURI:               "https://api.twitter.com/oauth/access_token",
+			Credentials:                   oauthCredentials,
+		},
 		Credentials: &oauth.Credentials{
 			Token:  access_token,
 			Secret: access_token_secret,
@@ -138,13 +141,13 @@ func NewTwitterApiWithCredentials(access_token string, access_token_secret strin
 //SetConsumerKey will set the application-specific consumer_key used in the initial OAuth process
 //This key is listed on https://dev.twitter.com/apps/YOUR_APP_ID/show
 func SetConsumerKey(consumer_key string) {
-	oauthClient.Credentials.Token = consumer_key
+	oauthCredentials.Token = consumer_key
 }
 
 //SetConsumerSecret will set the application-specific secret used in the initial OAuth process
 //This secret is listed on https://dev.twitter.com/apps/YOUR_APP_ID/show
 func SetConsumerSecret(consumer_secret string) {
-	oauthClient.Credentials.Secret = consumer_secret
+	oauthCredentials.Secret = consumer_secret
 }
 
 // ReturnRateLimitError specifies behavior when the Twitter API returns a rate-limit error.

--- a/twitter_test.go
+++ b/twitter_test.go
@@ -126,6 +126,15 @@ func Test_TwitterApi_NewTwitterApi(t *testing.T) {
 	}
 }
 
+// Test that creating a TwitterApi client creates a client with non-empty OAuth credentials
+func Test_TwitterApi_NewTwitterApiWithCredentials(t *testing.T) {
+	apiLocal := anaconda.NewTwitterApiWithCredentials(ACCESS_TOKEN, ACCESS_TOKEN_SECRET, CONSUMER_KEY, CONSUMER_SECRET)
+
+	if apiLocal.Credentials == nil {
+		t.Fatalf("Twitter Api client has empty (nil) credentials")
+	}
+}
+
 // Test that the GetSearch function actually works and returns non-empty results
 func Test_TwitterApi_GetSearch(t *testing.T) {
 	search_result, err := api.GetSearch("golang", nil)


### PR DESCRIPTION
Each TwitterApi now maintains its own oauthClient. The global oauthClient has been replaced by a slimmer global oauthCredentials to maintain backwards-compatibility with the old API.

This fixes #101 and is based on #182.

I'd appreciate a thorough review.