### PR TITLE
Linter fixes for internal variable names

### DIFF
--- a/account.go
+++ b/account.go
@@ -16,7 +16,7 @@ func (a TwitterApi) VerifyCredentials() (ok bool, err error) {
 
 // Get the user object for the authenticated user. Requests /account/verify_credentials
 func (a TwitterApi) GetSelf(v url.Values) (u User, err error) {
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/account/verify_credentials.json", v, &u, _GET, response_ch}
-	return u, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/account/verify_credentials.json", v, &u, _GET, ch}
+	return u, (<-ch).err
 }

--- a/lists.go
+++ b/lists.go
@@ -12,9 +12,9 @@ func (a TwitterApi) CreateList(name, description string, v url.Values) (list Lis
 	v.Set("name", name)
 	v.Set("description", description)
 
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/lists/create.json", v, &list, _POST, response_ch}
-	return list, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/lists/create.json", v, &list, _POST, ch}
+	return list, (<-ch).err
 }
 
 // AddUserToList implements /lists/members/create.json
@@ -25,9 +25,9 @@ func (a TwitterApi) AddUserToList(screenName string, listID int64, v url.Values)
 
 	var addUserToListResponse AddUserToListResponse
 
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/lists/members/create.json", v, &addUserToListResponse, _POST, response_ch}
-	return addUserToListResponse.Users, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/lists/members/create.json", v, &addUserToListResponse, _POST, ch}
+	return addUserToListResponse.Users, (<-ch).err
 }
 
 // AddMultipleUsersToList implements /lists/members/create_all.json
@@ -36,9 +36,9 @@ func (a TwitterApi) AddMultipleUsersToList(screenNames []string, listID int64, v
 	v.Set("list_id", strconv.FormatInt(listID, 10))
 	v.Set("screen_name", strings.Join(screenNames, ","))
 
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/lists/members/create_all.json", v, &list, _POST, response_ch}
-	r := <-response_ch
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/lists/members/create_all.json", v, &list, _POST, ch}
+	r := <-ch
 	return list, r.err
 }
 
@@ -50,19 +50,21 @@ func (a TwitterApi) GetListsOwnedBy(userID int64, v url.Values) (lists []List, e
 
 	var listResponse ListResponse
 
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/lists/ownerships.json", v, &listResponse, _GET, response_ch}
-	return listResponse.Lists, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/lists/ownerships.json", v, &listResponse, _GET, ch}
+	return listResponse.Lists, (<-ch).err
 }
 
+// GetListTweets implements /lists/statuses.json
+// Returns all tweets from users in a specific list
 func (a TwitterApi) GetListTweets(listID int64, includeRTs bool, v url.Values) (tweets []Tweet, err error) {
 	v = cleanValues(v)
 	v.Set("list_id", strconv.FormatInt(listID, 10))
 	v.Set("include_rts", strconv.FormatBool(includeRTs))
 
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/lists/statuses.json", v, &tweets, _GET, response_ch}
-	return tweets, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/lists/statuses.json", v, &tweets, _GET, ch}
+	return tweets, (<-ch).err
 }
 
 // GetList implements /lists/show.json
@@ -70,9 +72,9 @@ func (a TwitterApi) GetList(listID int64, v url.Values) (list List, err error) {
 	v = cleanValues(v)
 	v.Set("list_id", strconv.FormatInt(listID, 10))
 
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/lists/show.json", v, &list, _GET, response_ch}
-	return list, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/lists/show.json", v, &list, _GET, ch}
+	return list, (<-ch).err
 }
 
 func (a TwitterApi) GetListTweetsBySlug(slug string, ownerScreenName string, includeRTs bool, v url.Values) (tweets []Tweet, err error) {
@@ -81,7 +83,7 @@ func (a TwitterApi) GetListTweetsBySlug(slug string, ownerScreenName string, inc
 	v.Set("owner_screen_name", ownerScreenName)
 	v.Set("include_rts", strconv.FormatBool(includeRTs))
 
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/lists/statuses.json", v, &tweets, _GET, response_ch}
-	return tweets, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/lists/statuses.json", v, &tweets, _GET, ch}
+	return tweets, (<-ch).err
 }

--- a/media.go
+++ b/media.go
@@ -42,9 +42,9 @@ func (a TwitterApi) UploadMedia(base64String string) (media Media, err error) {
 
 	var mediaResponse Media
 
-	response_ch := make(chan response)
-	a.queryQueue <- query{UploadBaseUrl + "/media/upload.json", v, &mediaResponse, _POST, response_ch}
-	return mediaResponse, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{UploadBaseUrl + "/media/upload.json", v, &mediaResponse, _POST, ch}
+	return mediaResponse, (<-ch).err
 }
 
 func (a TwitterApi) UploadVideoInit(totalBytes int, mimeType string) (chunkedMedia ChunkedMedia, err error) {
@@ -55,9 +55,9 @@ func (a TwitterApi) UploadVideoInit(totalBytes int, mimeType string) (chunkedMed
 
 	var mediaResponse ChunkedMedia
 
-	response_ch := make(chan response)
-	a.queryQueue <- query{UploadBaseUrl + "/media/upload.json", v, &mediaResponse, _POST, response_ch}
-	return mediaResponse, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{UploadBaseUrl + "/media/upload.json", v, &mediaResponse, _POST, ch}
+	return mediaResponse, (<-ch).err
 }
 
 func (a TwitterApi) UploadVideoAppend(mediaIdString string,
@@ -71,9 +71,9 @@ func (a TwitterApi) UploadVideoAppend(mediaIdString string,
 
 	var emptyResponse interface{}
 
-	response_ch := make(chan response)
-	a.queryQueue <- query{UploadBaseUrl + "/media/upload.json", v, &emptyResponse, _POST, response_ch}
-	return (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{UploadBaseUrl + "/media/upload.json", v, &emptyResponse, _POST, ch}
+	return (<-ch).err
 }
 
 func (a TwitterApi) UploadVideoFinalize(mediaIdString string) (videoMedia VideoMedia, err error) {
@@ -83,7 +83,7 @@ func (a TwitterApi) UploadVideoFinalize(mediaIdString string) (videoMedia VideoM
 
 	var mediaResponse VideoMedia
 
-	response_ch := make(chan response)
-	a.queryQueue <- query{UploadBaseUrl + "/media/upload.json", v, &mediaResponse, _POST, response_ch}
-	return mediaResponse, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{UploadBaseUrl + "/media/upload.json", v, &mediaResponse, _POST, ch}
+	return mediaResponse, (<-ch).err
 }

--- a/mutes.go
+++ b/mutes.go
@@ -6,15 +6,15 @@ import (
 )
 
 func (a TwitterApi) GetMutedUsersList(v url.Values) (c UserCursor, err error) {
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/mutes/users/list.json", v, &c, _GET, response_ch}
-	return c, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/mutes/users/list.json", v, &c, _GET, ch}
+	return c, (<-ch).err
 }
 
 func (a TwitterApi) GetMutedUsersIds(v url.Values) (c Cursor, err error) {
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/mutes/users/ids.json", v, &c, _GET, response_ch}
-	return c, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/mutes/users/ids.json", v, &c, _GET, ch}
+	return c, (<-ch).err
 }
 
 func (a TwitterApi) MuteUser(screenName string, v url.Values) (user User, err error) {
@@ -30,9 +30,9 @@ func (a TwitterApi) MuteUserId(id int64, v url.Values) (user User, err error) {
 }
 
 func (a TwitterApi) Mute(v url.Values) (user User, err error) {
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/mutes/users/create.json", v, &user, _POST, response_ch}
-	return user, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/mutes/users/create.json", v, &user, _POST, ch}
+	return user, (<-ch).err
 }
 
 func (a TwitterApi) UnmuteUser(screenName string, v url.Values) (user User, err error) {
@@ -48,7 +48,7 @@ func (a TwitterApi) UnmuteUserId(id int64, v url.Values) (user User, err error) 
 }
 
 func (a TwitterApi) Unmute(v url.Values) (user User, err error) {
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/mutes/users/destroy.json", v, &user, _POST, response_ch}
-	return user, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/mutes/users/destroy.json", v, &user, _POST, ch}
+	return user, (<-ch).err
 }

--- a/rate_limit_status.go
+++ b/rate_limit_status.go
@@ -24,7 +24,7 @@ func (a TwitterApi) GetRateLimits(r []string) (rateLimitStatusResponse RateLimit
 	resources := strings.Join(r, ",")
 	v := url.Values{}
 	v.Set("resources", resources)
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/application/rate_limit_status.json", v, &rateLimitStatusResponse, _GET, response_ch}
-	return rateLimitStatusResponse, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/application/rate_limit_status.json", v, &rateLimitStatusResponse, _GET, ch}
+	return rateLimitStatusResponse, (<-ch).err
 }

--- a/search.go
+++ b/search.go
@@ -25,12 +25,12 @@ func (sr *SearchResponse) GetNext(a *TwitterApi) (SearchResponse, error) {
 	if sr.Metadata.NextResults == "" {
 		return SearchResponse{}, nil
 	}
-	nextUrl, err := url.Parse(sr.Metadata.NextResults)
+	nextURL, err := url.Parse(sr.Metadata.NextResults)
 	if err != nil {
 		return SearchResponse{}, err
 	}
 
-	v := nextUrl.Query()
+	v := nextURL.Query()
 	// remove the q parameter from the url.Values so that it
 	// can be added back via the next GetSearch method call.
 	delete(v, "q")
@@ -46,12 +46,12 @@ func (sr *SearchResponse) GetNext(a *TwitterApi) (SearchResponse, error) {
 func (a TwitterApi) GetSearch(queryString string, v url.Values) (sr SearchResponse, err error) {
 	v = cleanValues(v)
 	v.Set("q", queryString)
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/search/tweets.json", v, &sr, _GET, response_ch}
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/search/tweets.json", v, &sr, _GET, ch}
 
 	// We have to read from the response channel before assigning to timeline
 	// Otherwise this will happen before the responses have been written
-	resp := <-response_ch
+	resp := <-ch
 	err = resp.err
 	return sr, err
 }

--- a/timeline.go
+++ b/timeline.go
@@ -14,32 +14,32 @@ func (a TwitterApi) GetHomeTimeline(v url.Values) (timeline []Tweet, err error) 
 		v.Set("include_entities", "true")
 	}
 
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/statuses/home_timeline.json", v, &timeline, _GET, response_ch}
-	return timeline, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/statuses/home_timeline.json", v, &timeline, _GET, ch}
+	return timeline, (<-ch).err
 }
 
 // GetUserTimeline returns a collection of the most recent Tweets posted by the user indicated by the screen_name or user_id parameters.
 // https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-user_timeline
 func (a TwitterApi) GetUserTimeline(v url.Values) (timeline []Tweet, err error) {
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/statuses/user_timeline.json", v, &timeline, _GET, response_ch}
-	return timeline, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/statuses/user_timeline.json", v, &timeline, _GET, ch}
+	return timeline, (<-ch).err
 }
 
 // GetMentionsTimeline returns the most recent mentions (Tweets containing a users’s @screen_name) for the authenticating user.
 // The timeline returned is the equivalent of the one seen when you view your mentions on twitter.com.
 // https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-mentions_timeline
 func (a TwitterApi) GetMentionsTimeline(v url.Values) (timeline []Tweet, err error) {
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/statuses/mentions_timeline.json", v, &timeline, _GET, response_ch}
-	return timeline, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/statuses/mentions_timeline.json", v, &timeline, _GET, ch}
+	return timeline, (<-ch).err
 }
 
 // GetRetweetsOfMe returns the most recent Tweets authored by the authenticating user that have been retweeted by others.
 // https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-retweets_of_me
 func (a TwitterApi) GetRetweetsOfMe(v url.Values) (tweets []Tweet, err error) {
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/statuses/retweets_of_me.json", v, &tweets, _GET, response_ch}
-	return tweets, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/statuses/retweets_of_me.json", v, &tweets, _GET, ch}
+	return tweets, (<-ch).err
 }

--- a/trends.go
+++ b/trends.go
@@ -39,26 +39,26 @@ type TrendLocation struct {
 
 // https://dev.twitter.com/rest/reference/get/trends/place
 func (a TwitterApi) GetTrendsByPlace(id int64, v url.Values) (trendResp TrendResponse, err error) {
-	response_ch := make(chan response)
+	ch := make(chan response)
 	v = cleanValues(v)
 	v.Set("id", strconv.FormatInt(id, 10))
-	a.queryQueue <- query{a.baseUrl + "/trends/place.json", v, &[]interface{}{&trendResp}, _GET, response_ch}
-	return trendResp, (<-response_ch).err
+	a.queryQueue <- query{a.baseUrl + "/trends/place.json", v, &[]interface{}{&trendResp}, _GET, ch}
+	return trendResp, (<-ch).err
 }
 
 // https://dev.twitter.com/rest/reference/get/trends/available
 func (a TwitterApi) GetTrendsAvailableLocations(v url.Values) (locations []TrendLocation, err error) {
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/trends/available.json", v, &locations, _GET, response_ch}
-	return locations, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/trends/available.json", v, &locations, _GET, ch}
+	return locations, (<-ch).err
 }
 
 // https://dev.twitter.com/rest/reference/get/trends/closest
 func (a TwitterApi) GetTrendsClosestLocations(lat float64, long float64, v url.Values) (locations []TrendLocation, err error) {
-	response_ch := make(chan response)
+	ch := make(chan response)
 	v = cleanValues(v)
 	v.Set("lat", strconv.FormatFloat(lat, 'f', 6, 64))
 	v.Set("long", strconv.FormatFloat(long, 'f', 6, 64))
-	a.queryQueue <- query{a.baseUrl + "/trends/closest.json", v, &locations, _GET, response_ch}
-	return locations, (<-response_ch).err
+	a.queryQueue <- query{a.baseUrl + "/trends/closest.json", v, &locations, _GET, ch}
+	return locations, (<-ch).err
 }

--- a/tweets.go
+++ b/tweets.go
@@ -10,9 +10,9 @@ func (a TwitterApi) GetTweet(id int64, v url.Values) (tweet Tweet, err error) {
 	v = cleanValues(v)
 	v.Set("id", strconv.FormatInt(id, 10))
 
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/statuses/show.json", v, &tweet, _GET, response_ch}
-	return tweet, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/statuses/show.json", v, &tweet, _GET, ch}
+	return tweet, (<-ch).err
 }
 
 func (a TwitterApi) GetTweetsLookupByIds(ids []int64, v url.Values) (tweet []Tweet, err error) {
@@ -25,24 +25,24 @@ func (a TwitterApi) GetTweetsLookupByIds(ids []int64, v url.Values) (tweet []Twe
 	}
 	v = cleanValues(v)
 	v.Set("id", pids)
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/statuses/lookup.json", v, &tweet, _GET, response_ch}
-	return tweet, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/statuses/lookup.json", v, &tweet, _GET, ch}
+	return tweet, (<-ch).err
 }
 
 func (a TwitterApi) GetRetweets(id int64, v url.Values) (tweets []Tweet, err error) {
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + fmt.Sprintf("/statuses/retweets/%d.json", id), v, &tweets, _GET, response_ch}
-	return tweets, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + fmt.Sprintf("/statuses/retweets/%d.json", id), v, &tweets, _GET, ch}
+	return tweets, (<-ch).err
 }
 
 //PostTweet will create a tweet with the specified status message
 func (a TwitterApi) PostTweet(status string, v url.Values) (tweet Tweet, err error) {
 	v = cleanValues(v)
 	v.Set("status", status)
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/statuses/update.json", v, &tweet, _POST, response_ch}
-	return tweet, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/statuses/update.json", v, &tweet, _POST, ch}
+	return tweet, (<-ch).err
 }
 
 //DeleteTweet will destroy (delete) the status (tweet) with the specified ID, assuming that the authenticated user is the author of the status (tweet).
@@ -52,9 +52,9 @@ func (a TwitterApi) DeleteTweet(id int64, trimUser bool) (tweet Tweet, err error
 	if trimUser {
 		v.Set("trim_user", "t")
 	}
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + fmt.Sprintf("/statuses/destroy/%d.json", id), v, &tweet, _POST, response_ch}
-	return tweet, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + fmt.Sprintf("/statuses/destroy/%d.json", id), v, &tweet, _POST, ch}
+	return tweet, (<-ch).err
 }
 
 //Retweet will retweet the status (tweet) with the specified ID.
@@ -64,9 +64,9 @@ func (a TwitterApi) Retweet(id int64, trimUser bool) (rt Tweet, err error) {
 	if trimUser {
 		v.Set("trim_user", "t")
 	}
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + fmt.Sprintf("/statuses/retweet/%d.json", id), v, &rt, _POST, response_ch}
-	return rt, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + fmt.Sprintf("/statuses/retweet/%d.json", id), v, &rt, _POST, ch}
+	return rt, (<-ch).err
 }
 
 //UnRetweet will renove retweet Untweets a retweeted status.
@@ -80,9 +80,9 @@ func (a TwitterApi) UnRetweet(id int64, trimUser bool) (rt Tweet, err error) {
 	if trimUser {
 		v.Set("trim_user", "t")
 	}
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + fmt.Sprintf("/statuses/unretweet/%d.json", id), v, &rt, _POST, response_ch}
-	return rt, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + fmt.Sprintf("/statuses/unretweet/%d.json", id), v, &rt, _POST, ch}
+	return rt, (<-ch).err
 }
 
 // Favorite will favorite the status (tweet) with the specified ID.
@@ -90,9 +90,9 @@ func (a TwitterApi) UnRetweet(id int64, trimUser bool) (rt Tweet, err error) {
 func (a TwitterApi) Favorite(id int64) (rt Tweet, err error) {
 	v := url.Values{}
 	v.Set("id", fmt.Sprint(id))
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + fmt.Sprintf("/favorites/create.json"), v, &rt, _POST, response_ch}
-	return rt, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + fmt.Sprintf("/favorites/create.json"), v, &rt, _POST, ch}
+	return rt, (<-ch).err
 }
 
 // Un-favorites the status specified in the ID parameter as the authenticating user.
@@ -101,7 +101,7 @@ func (a TwitterApi) Favorite(id int64) (rt Tweet, err error) {
 func (a TwitterApi) Unfavorite(id int64) (rt Tweet, err error) {
 	v := url.Values{}
 	v.Set("id", fmt.Sprint(id))
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + fmt.Sprintf("/favorites/destroy.json"), v, &rt, _POST, response_ch}
-	return rt, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + fmt.Sprintf("/favorites/destroy.json"), v, &rt, _POST, ch}
+	return rt, (<-ch).err
 }

--- a/twitter.go
+++ b/twitter.go
@@ -104,14 +104,14 @@ const DEFAULT_CAPACITY = 5
 
 //NewTwitterApi takes an user-specific access token and secret and returns a TwitterApi struct for that user.
 //The TwitterApi struct can be used for accessing any of the endpoints available.
-func NewTwitterApi(access_token string, access_token_secret string) *TwitterApi {
+func NewTwitterApi(accessToken string, accessTokenSecret string) *TwitterApi {
 	//TODO figure out how much to buffer this channel
 	//A non-buffered channel will cause blocking when multiple queries are made at the same time
 	queue := make(chan query)
 	c := &TwitterApi{
 		Credentials: &oauth.Credentials{
-			Token:  access_token,
-			Secret: access_token_secret,
+			Token:  accessToken,
+			Secret: accessTokenSecret,
 		},
 		queryQueue:           queue,
 		bucket:               nil,
@@ -126,14 +126,14 @@ func NewTwitterApi(access_token string, access_token_secret string) *TwitterApi 
 
 //SetConsumerKey will set the application-specific consumer_key used in the initial OAuth process
 //This key is listed on https://dev.twitter.com/apps/YOUR_APP_ID/show
-func SetConsumerKey(consumer_key string) {
-	oauthClient.Credentials.Token = consumer_key
+func SetConsumerKey(consumerKey string) {
+	oauthClient.Credentials.Token = consumerKey
 }
 
 //SetConsumerSecret will set the application-specific secret used in the initial OAuth process
 //This secret is listed on https://dev.twitter.com/apps/YOUR_APP_ID/show
-func SetConsumerSecret(consumer_secret string) {
-	oauthClient.Credentials.Secret = consumer_secret
+func SetConsumerSecret(consumerSecret string) {
+	oauthClient.Credentials.Secret = consumerSecret
 }
 
 // ReturnRateLimitError specifies behavior when the Twitter API returns a rate-limit error.

--- a/users.go
+++ b/users.go
@@ -8,9 +8,9 @@ import (
 func (a TwitterApi) GetUsersLookup(usernames string, v url.Values) (u []User, err error) {
 	v = cleanValues(v)
 	v.Set("screen_name", usernames)
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/users/lookup.json", v, &u, _GET, response_ch}
-	return u, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/users/lookup.json", v, &u, _GET, ch}
+	return u, (<-ch).err
 }
 
 func (a TwitterApi) GetUsersLookupByIds(ids []int64, v url.Values) (u []User, err error) {
@@ -24,25 +24,25 @@ func (a TwitterApi) GetUsersLookupByIds(ids []int64, v url.Values) (u []User, er
 	}
 	v = cleanValues(v)
 	v.Set("user_id", pids)
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/users/lookup.json", v, &u, _GET, response_ch}
-	return u, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/users/lookup.json", v, &u, _GET, ch}
+	return u, (<-ch).err
 }
 
 func (a TwitterApi) GetUsersShow(username string, v url.Values) (u User, err error) {
 	v = cleanValues(v)
 	v.Set("screen_name", username)
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/users/show.json", v, &u, _GET, response_ch}
-	return u, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/users/show.json", v, &u, _GET, ch}
+	return u, (<-ch).err
 }
 
 func (a TwitterApi) GetUsersShowById(id int64, v url.Values) (u User, err error) {
 	v = cleanValues(v)
 	v.Set("user_id", strconv.FormatInt(id, 10))
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/users/show.json", v, &u, _GET, response_ch}
-	return u, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/users/show.json", v, &u, _GET, ch}
+	return u, (<-ch).err
 }
 
 func (a TwitterApi) GetUserSearch(searchTerm string, v url.Values) (u []User, err error) {
@@ -50,18 +50,18 @@ func (a TwitterApi) GetUserSearch(searchTerm string, v url.Values) (u []User, er
 	v.Set("q", searchTerm)
 	// Set other values before calling this method:
 	// page, count, include_entities
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/users/search.json", v, &u, _GET, response_ch}
-	return u, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/users/search.json", v, &u, _GET, ch}
+	return u, (<-ch).err
 }
 
 func (a TwitterApi) GetUsersSuggestions(v url.Values) (u []User, err error) {
 	v = cleanValues(v)
 	// Set other values before calling this method:
 	// page, count, include_entities
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/users/suggestions.json", v, &u, _GET, response_ch}
-	return u, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/users/suggestions.json", v, &u, _GET, ch}
+	return u, (<-ch).err
 }
 
 // PostUsersReportSpam : Reports and Blocks a User by screen_name
@@ -71,9 +71,9 @@ func (a TwitterApi) GetUsersSuggestions(v url.Values) (u []User, err error) {
 func (a TwitterApi) PostUsersReportSpam(username string, v url.Values) (u User, err error) {
 	v = cleanValues(v)
 	v.Set("screen_name", username)
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/users/report_spam.json", v, &u, _POST, response_ch}
-	return u, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/users/report_spam.json", v, &u, _POST, ch}
+	return u, (<-ch).err
 }
 
 // PostUsersReportSpamById : Reports and Blocks a User by user_id
@@ -83,7 +83,7 @@ func (a TwitterApi) PostUsersReportSpam(username string, v url.Values) (u User, 
 func (a TwitterApi) PostUsersReportSpamById(id int64, v url.Values) (u User, err error) {
 	v = cleanValues(v)
 	v.Set("user_id", strconv.FormatInt(id, 10))
-	response_ch := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/users/report_spam.json", v, &u, _POST, response_ch}
-	return u, (<-response_ch).err
+	ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/users/report_spam.json", v, &u, _POST, ch}
+	return u, (<-ch).err
 }


### PR DESCRIPTION
A few simple fixes for linter warnings in the form of `don't use underscores in Go names`.