### PR TITLE
Enforce a default HTTP client timeout

### DIFF
--- a/twitter.go
+++ b/twitter.go
@@ -58,6 +58,7 @@ const (
 	_POST         = iota
 	_DELETE       = iota
 	_PUT          = iota
+	ClientTimeout = 20
 	BaseUrlV1     = "https://api.twitter.com/1"
 	BaseUrl       = "https://api.twitter.com/1.1"
 	UploadBaseUrl = "https://upload.twitter.com/1.1"
@@ -125,6 +126,8 @@ func NewTwitterApi(access_token string, access_token_secret string) *TwitterApi 
 		Log:                  silentLogger{},
 		baseUrl:              BaseUrl,
 	}
+	//Configure a timeout to HTTP client (DefaultClient has no default timeout, which may deadlock Mutex-wrapped uses of the lib.)
+	c.HttpClient.Timeout = time.Duration(ClientTimeout * time.Second)
 	go c.throttledQuery()
 	return c
 }

--- a/twitter.go
+++ b/twitter.go
@@ -278,7 +278,8 @@ func decodeResponse(resp *http.Response, data interface{}) error {
 
 	// according to dev.twitter.com, chunked upload append returns HTTP 2XX
 	// so we need a special case when decoding the response
-	if strings.HasSuffix(resp.Request.URL.String(), "upload.json") {
+	if strings.HasSuffix(resp.Request.URL.String(), "upload.json") ||
+		strings.Contains(resp.Request.URL.String(), "webhooks") {
 		if resp.StatusCode == 204 {
 			// empty response, don't decode
 			return nil
@@ -312,9 +313,9 @@ func (c TwitterApi) execQuery(urlStr string, form url.Values, data interface{}, 
 	case _POST:
 		return c.apiPost(urlStr, form, data)
 	case _DELETE:
-		return c.apiPost(urlStr, form, data)
+		return c.apiDel(urlStr, form, data)
 	case _PUT:
-		return c.apiPost(urlStr, form, data)
+		return c.apiPut(urlStr, form, data)
 	default:
 		return fmt.Errorf("HTTP method not yet supported")
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -7,8 +7,9 @@ import (
 //GetActivityWebhooks represents the twitter account_activity webhook
 //Returns all URLs and their statuses for the given app. Currently,
 //only one webhook URL can be registered to an application.
-//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/get-webhook-config
+//https://dev.twitter.com/webhooks/reference/get/account_activity/webhooks
 func (a TwitterApi) GetActivityWebhooks(v url.Values) (u []WebHookResp, err error) {
+	v = cleanValues(v)
 	responseCh := make(chan response)
 	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks.json", v, &u, _GET, responseCh}
 	return u, (<-responseCh).err
@@ -27,24 +28,27 @@ type WebHookResp struct {
 //The URL will be validated via CRC request before saving. In case the validation fails,
 //a comprehensive error is returned. message to the requester.
 //Only one webhook URL can be registered to an application.
-//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/new-webhook-config
-func (a TwitterApi) SetActivityWebhooks(v url.Values) (u []WebHookResp, err error) {
+//https://api.twitter.com/1.1/account_activity/webhooks.json
+func (a TwitterApi) SetActivityWebhooks(v url.Values) (u WebHookResp, err error) {
+	v = cleanValues(v)
 	responseCh := make(chan response)
 	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks.json", v, &u, _POST, responseCh}
 	return u, (<-responseCh).err
 }
 
 //DeleteActivityWebhooks Removes the webhook from the provided application’s configuration.
-//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/delete-webhook-config
+//https://dev.twitter.com/webhooks/reference/del/account_activity/webhooks
 func (a TwitterApi) DeleteActivityWebhooks(v url.Values, webhookID string) (u interface{}, err error) {
+	v = cleanValues(v)
 	responseCh := make(chan response)
 	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + ".json", v, &u, _DELETE, responseCh}
 	return u, (<-responseCh).err
 }
 
 //PutActivityWebhooks update webhook which reenables the webhook by setting its status to valid.
-//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/validate-webhook-config
+//https://dev.twitter.com/webhooks/reference/put/account_activity/webhooks
 func (a TwitterApi) PutActivityWebhooks(v url.Values, webhookID string) (u interface{}, err error) {
+	v = cleanValues(v)
 	responseCh := make(chan response)
 	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + ".json", v, &u, _PUT, responseCh}
 	return u, (<-responseCh).err
@@ -52,8 +56,9 @@ func (a TwitterApi) PutActivityWebhooks(v url.Values, webhookID string) (u inter
 
 //SetWHSubscription Subscribes the provided app to events for the provided user context.
 //When subscribed, all DM events for the provided user will be sent to the app’s webhook via POST request.
-//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/new-subscription
+//https://dev.twitter.com/webhooks/reference/post/account_activity/webhooks/subscriptions
 func (a TwitterApi) SetWHSubscription(v url.Values, webhookID string) (u interface{}, err error) {
+	v = cleanValues(v)
 	responseCh := make(chan response)
 	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + "/subscriptions.json", v, &u, _POST, responseCh}
 	return u, (<-responseCh).err
@@ -61,8 +66,9 @@ func (a TwitterApi) SetWHSubscription(v url.Values, webhookID string) (u interfa
 
 //GetWHSubscription Provides a way to determine if a webhook configuration is
 //subscribed to the provided user’s Direct Messages.
-//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/get-subscription
+//https://dev.twitter.com/webhooks/reference/get/account_activity/webhooks/subscriptions
 func (a TwitterApi) GetWHSubscription(v url.Values, webhookID string) (u interface{}, err error) {
+	v = cleanValues(v)
 	responseCh := make(chan response)
 	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + "/subscriptions.json", v, &u, _GET, responseCh}
 	return u, (<-responseCh).err
@@ -70,8 +76,9 @@ func (a TwitterApi) GetWHSubscription(v url.Values, webhookID string) (u interfa
 
 //DeleteWHSubscription Deactivates subscription for the provided user context and app. After deactivation,
 //all DM events for the requesting user will no longer be sent to the webhook URL..
-//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/delete-subscription
+//https://dev.twitter.com/webhooks/reference/del/account_activity/webhooks
 func (a TwitterApi) DeleteWHSubscription(v url.Values, webhookID string) (u interface{}, err error) {
+	v = cleanValues(v)
 	responseCh := make(chan response)
 	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + "/subscriptions.json", v, &u, _DELETE, responseCh}
 	return u, (<-responseCh).err


### PR DESCRIPTION
Golang default HTTP client has no timeout, which may dead-lock any wrapper mutex when used in a complex app, in case the network goes down or Twitter APIs take too much time to respond / are down.

See: https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779

Signed-off-by: Valerian Saliou <valerian@valeriansaliou.name>