### PR TITLE
Disable Travis Go 1.6 tests on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,15 @@ before_script:
   - git diff-index --cached --exit-code HEAD
 
 go:
-  - 1.6
   - 1.7
   - 1.8
   - 1.9
   - tip
+
+matrix:
+    include:
+        - os: linux
+          go: 1.6
 
 script:
   - echo $TRAVIS_GO_VERSION


### PR DESCRIPTION
The OS X images on Travis for Go 1.6 are broken and fail to start, causing the entire build to fail. This patch will keep testing 1.6 on Linux, but OS X will only be tested from 1.7 onward.


This will fix the build failures on https://github.com/ChimeraCoder/anaconda/pull/222.