### PR TITLE
Use exclude instead of include directive for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,15 @@ before_script:
   - git diff-index --cached --exit-code HEAD
 
 go:
+  - 1.6
   - 1.7
   - 1.8
   - 1.9
   - tip
 
 matrix:
-    include:
-        - os: linux
+    exclude:
+        - os: osx
           go: 1.6
 
 script:


### PR DESCRIPTION
Per https://github.com/ChimeraCoder/anaconda/commit/37d498d409d0ec1fbd0ffa155a4db612e2ce7f54#commitcomment-27765012, this will have the same behavior but preserve sorting order of the platform/version combinations in Travis.