### PR TITLE
Add IndicateTyping endpoint

### DIFF
--- a/directmessages.go
+++ b/directmessages.go
@@ -55,3 +55,13 @@ func (a TwitterApi) postDirectMessagesImpl(v url.Values) (message DirectMessage,
 	a.queryQueue <- query{a.baseUrl + "/direct_messages/new.json", v, &message, _POST, response_ch}
 	return message, (<-response_ch).err
 }
+
+// IndicateTyping will create a typing indicator
+// https://developer.twitter.com/en/docs/direct-messages/typing-indicator-and-read-receipts/api-reference/new-typing-indicator
+func (a TwitterApi) IndicateTyping(id int64) (err error) {
+	v := url.Values{}
+	v.Set("recipient_id", strconv.FormatInt(id, 10))
+	response_ch := make(chan response)
+	a.queryQueue <- query{a.baseUrl + "/direct_messages/indicate_typing.json", v, nil, _POST, response_ch}
+	return (<-response_ch).err
+}


### PR DESCRIPTION
Implement the `/direct_messages/indicate_typing.json` endpoint.


Originally submitted by valeriansaliou in https://github.com/ChimeraCoder/anaconda/pull/226, but split into a separate PR for clarity.