### PR TITLE
add symbols entity object to entities struct

### DIFF
--- a/twitter_entities.go
+++ b/twitter_entities.go
@@ -20,6 +20,10 @@ type Entities struct {
 		Indices []int  `json:"indices"`
 		Text    string `json:"text"`
 	} `json:"hashtags"`
+	Symbols []struct {
+		Indices []int  `json:"indices"`
+		Text    string `json:"text"`
+	} `json:"symbols"`
 	Url           UrlEntity `json:"url"`
 	User_mentions []struct {
 		Name        string `json:"name"`


### PR DESCRIPTION
Added the symbols entity to the entities struct.

The symbols entity represents $cashtags, included in the text of the Tweet. Example:
`
{
  "symbols": [
    {
      "indices": [
        12,
        17
      ],
      "text": "twtr"
    }
  ]
}
`

ref: https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/entities-object#symbols

fixes #103 

