### PR TITLE
Add TweetVolume to Trend Structure

### DIFF
--- a/trends.go
+++ b/trends.go
@@ -15,6 +15,7 @@ type Trend struct {
 	Query           string `json:"query"`
 	Url             string `json:"url"`
 	PromotedContent string `json:"promoted_content"`
+	TweetVolume     string `json:"tweet_volume"`
 }
 
 type TrendResponse struct {


### PR DESCRIPTION
Changes Made : 
  - Added a field to Trend Structure to permit to get tweet_volume from twitter Api ( [https://developer.twitter.com/en/docs/trends/trends-for-location/api-reference/get-trends-place](url)