### PR TITLE
Account Activity API updates

### DIFF
--- a/README
+++ b/README
@@ -41,36 +41,6 @@ result, err := api.GetSearch("golang", v)
 
 (Remember that `url.Values` is equivalent to a `map[string][]string`, if you find that more convenient notation when specifying values). Otherwise, `nil` suffices.
 
-### Streaming
-
-Anaconda supports the Streaming APIs. You can use `PublicStream*` or `UserStream` API methods.
-A go loop is started an gives you an stream that sends `interface{}` objects through it's `chan` `C`
-Objects which you can cast into a tweet, event and more.
-
-
-````go
-v := url.Values{}
-s := api.UserStream(v)
-
-for t := range s.C {
-  switch v := t.(type) {
-  case anaconda.Tweet:
-    fmt.Printf("%-15s: %s\n", v.User.ScreenName, v.Text)
-  case anaconda.EventTweet:
-    switch v.Event.Event {
-    case "favorite":
-      sn := v.Source.ScreenName
-      tw := v.TargetObject.Text
-      fmt.Printf("Favorited by %-15s: %s\n", sn, tw)
-    case "unfavorite":
-      sn := v.Source.ScreenName
-      tw := v.TargetObject.Text
-      fmt.Printf("UnFavorited by %-15s: %s\n", sn, tw)
-    }
-  }
-}
-````
-
 
 
 Endpoints

--- a/webhook.go
+++ b/webhook.go
@@ -1,17 +1,22 @@
 package anaconda
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/http"
 	"net/url"
 )
 
 //GetActivityWebhooks represents the twitter account_activity webhook
 //Returns all URLs and their statuses for the given app. Currently,
-//only one webhook URL can be registered to an application.
-//https://dev.twitter.com/webhooks/reference/get/account_activity/webhooks
+//only one webhook URL can be registered to an application except in the Enterprise API
+//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#get-account-activity-all-webhooks
 func (a TwitterApi) GetActivityWebhooks(v url.Values) (u []WebHookResp, err error) {
 	v = cleanValues(v)
 	responseCh := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks.json", v, &u, _GET, responseCh}
+	a.queryQueue <- query{a.activityUrl + "webhooks.json", v, &u, _GET, responseCh}
 	return u, (<-responseCh).err
 }
 
@@ -23,63 +28,111 @@ type WebHookResp struct {
 	CreatedAt string
 }
 
+type BearerToken struct {
+	Type  string `json:"token_type"`
+	Token string `json:"access_token"`
+}
+
 //SetActivityWebhooks represents to set twitter account_activity webhook
 //Registers a new webhook URL for the given application context.
 //The URL will be validated via CRC request before saving. In case the validation fails,
-//a comprehensive error is returned. message to the requester.
-//Only one webhook URL can be registered to an application.
-//https://api.twitter.com/1.1/account_activity/webhooks.json
+//a comprehensive error message is returned to the requester.
+//Only one webhook URL can be registered to an application except in the Enterprise API.
+//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#post-account-activity-all-env-name-webhooks
 func (a TwitterApi) SetActivityWebhooks(v url.Values) (u WebHookResp, err error) {
 	v = cleanValues(v)
 	responseCh := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks.json", v, &u, _POST, responseCh}
+	a.queryQueue <- query{a.activityUrl + "webhooks.json", v, &u, _POST, responseCh}
 	return u, (<-responseCh).err
 }
 
-//DeleteActivityWebhooks Removes the webhook from the provided application’s configuration.
-//https://dev.twitter.com/webhooks/reference/del/account_activity/webhooks
+//DeleteActivityWebhooks Removes a webhook from the provided application’s configuration.
+//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#delete-account-activity-all-env-name-webhooks-webhook-id
 func (a TwitterApi) DeleteActivityWebhooks(v url.Values, webhookID string) (u interface{}, err error) {
 	v = cleanValues(v)
 	responseCh := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + ".json", v, &u, _DELETE, responseCh}
+	a.queryQueue <- query{a.activityUrl + "webhooks/" + webhookID + ".json", v, &u, _DELETE, responseCh}
 	return u, (<-responseCh).err
 }
 
-//PutActivityWebhooks update webhook which reenables the webhook by setting its status to valid.
-//https://dev.twitter.com/webhooks/reference/put/account_activity/webhooks
+//PutActivityWebhooks Updates a webhook by triggering a challenge response check (CRC) which, if
+//successful, sets its status to valid.
+//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#put-account-activity-all-env-name-webhooks-webhook-id
 func (a TwitterApi) PutActivityWebhooks(v url.Values, webhookID string) (u interface{}, err error) {
 	v = cleanValues(v)
 	responseCh := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + ".json", v, &u, _PUT, responseCh}
+	a.queryQueue <- query{a.activityUrl + "webhooks/" + webhookID + ".json", v, &u, _PUT, responseCh}
 	return u, (<-responseCh).err
 }
 
 //SetWHSubscription Subscribes the provided app to events for the provided user context.
-//When subscribed, all DM events for the provided user will be sent to the app’s webhook via POST request.
-//https://dev.twitter.com/webhooks/reference/post/account_activity/webhooks/subscriptions
+//When subscribed, all events for the provided user will be sent to the app’s webhook via POST request.
+//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#post-account-activity-all-env-name-subscriptions
 func (a TwitterApi) SetWHSubscription(v url.Values, webhookID string) (u interface{}, err error) {
 	v = cleanValues(v)
 	responseCh := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + "/subscriptions.json", v, &u, _POST, responseCh}
+	if a.env != "" {
+		a.queryQueue <- query{a.activityUrl + "subscriptions.json", v, &u, _POST, responseCh}
+	} else {
+		a.queryQueue <- query{a.activityUrl + "webhooks/" + webhookID + "/subscriptions/all.json", v, &u, _POST, responseCh}
+	}
 	return u, (<-responseCh).err
 }
 
-//GetWHSubscription Provides a way to determine if a webhook configuration is
-//subscribed to the provided user’s Direct Messages.
-//https://dev.twitter.com/webhooks/reference/get/account_activity/webhooks/subscriptions
+//GetWHSubscription Determines if a webhook configuration is subscribed to the provided user’s account
+//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#get-account-activity-all-env-name-subscriptions
 func (a TwitterApi) GetWHSubscription(v url.Values, webhookID string) (u interface{}, err error) {
 	v = cleanValues(v)
 	responseCh := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + "/subscriptions.json", v, &u, _GET, responseCh}
+	if a.env != "" {
+		a.queryQueue <- query{a.activityUrl + "subscriptions.json", v, &u, _GET, responseCh}
+	} else {
+		a.queryQueue <- query{a.activityUrl + "webhooks/" + webhookID + "/subscriptions/all.json", v, &u, _GET, responseCh}
+	}
+	return u, (<-responseCh).err
+}
+
+//ListWHSubscriptions Returns a list of active subscriptions
+//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#get-account-activity-all-env-name-subscriptions-list
+func (a TwitterApi) ListWHSubscriptions(v url.Values) (u interface{}, err error) {
+	v = cleanValues(v)
+	responseCh := make(chan response)
+
+	a.queryQueue <- query{a.activityUrl + "subscriptions/list.json", v, &u, _GETBEARER, responseCh}
 	return u, (<-responseCh).err
 }
 
 //DeleteWHSubscription Deactivates subscription for the provided user context and app. After deactivation,
-//all DM events for the requesting user will no longer be sent to the webhook URL..
+//all events for the requesting user will no longer be sent to the webhook URL.
 //https://dev.twitter.com/webhooks/reference/del/account_activity/webhooks
 func (a TwitterApi) DeleteWHSubscription(v url.Values, webhookID string) (u interface{}, err error) {
 	v = cleanValues(v)
 	responseCh := make(chan response)
-	a.queryQueue <- query{a.baseUrl + "/account_activity/webhooks/" + webhookID + "/subscriptions.json", v, &u, _DELETE, responseCh}
+	if a.env != "" {
+		a.queryQueue <- query{a.activityUrl + "subscriptions.json", v, &u, _DELETE, responseCh}
+	} else {
+		a.queryQueue <- query{a.activityUrl + "webhooks/" + webhookID + "/subscriptions/all.json", v, &u, _DELETE, responseCh}
+	}
 	return u, (<-responseCh).err
+}
+
+//CountWHSubscriptions returns the count of subscriptions active on a given webhook
+//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#get-account-activity-all-subscriptions-count
+func (a TwitterApi) CountWHSubscriptions(v url.Values) (u interface{}, err error) {
+	v = cleanValues(v)
+	responseCh := make(chan response)
+	//note lack of environment name here, even for Premium
+
+	a.queryQueue <- query{a.baseUrl + "/account_activity/all/subscriptions/count.json", v, &u, _GETBEARER, responseCh}
+	return u, (<-responseCh).err
+}
+
+//RespondCRC responds to a CRC request from Twitter.
+//Should be called in response to a GET request to the callback URL.
+//https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/guides/securing-webhooks
+func (a TwitterApi) RespondCRC(tok string, w http.ResponseWriter) {
+	mac := hmac.New(sha256.New, []byte(a.oauthClient.Credentials.Secret))
+	mac.Write([]byte(tok))
+	resp := "{ \"response_token\": \"sha256=" + base64.StdEncoding.EncodeToString(mac.Sum(nil)) + "\" }"
+	fmt.Fprint(w, resp)
 }


### PR DESCRIPTION
This is an extension to support the Account Activity API, primarily to support enhancements that were made to take the place of some of the capabilities of the (now sunset) Streaming API. It is not fully tested and is perhaps incomplete, so I'm not sure it's really ready to merge, but since I'm moving on to something else (see below), I wanted to contribute what I have.

This includes:
* Support for environment names used with the Premium (and sandbox) version of the API. An empty environment name indicates the use of the Enterprise API (with somewhat different API URLs), although I have no way to test this.

* New support for OAuth 2.0 bearer tokens used when listing and counting webhook subscriptions. This is done outside the OAuth library because the currently-referenced library has no support for bearer tokens (but see also #257).

* Code for calculating and sending a CRC response to a webhook challenge GET request

* Removal of streaming example from README. Many API endpoints in `streaming.go` don't work, but some (particularly sampling and filtering tweets) still do, so I suspect that some of that code is still useful.

* Documentation and API URL updates

This pull request closes #254. I will be doing no further work on the Account Activity API because I just discovered that, unlike the Streaming API it is supposed to replace, it does not supply inbound home timeline tweets (only mentions, replies, likes, follows, etc.). I'm happy to answer any questions regarding the code, however.