### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/account.go
+++ b/account.go
@@ -14,7 +14,7 @@ func (a TwitterApi) VerifyCredentials() (ok bool, err error) {
 	return err == nil, err
 }
 
-// Get the user object for the authenticated user. Requests /account/verify_credentials
+// GetSelf gets the user object for the authenticated user. Requests /account/verify_credentials
 func (a TwitterApi) GetSelf(v url.Values) (u User, err error) {
 	response_ch := make(chan response)
 	a.queryQueue <- query{a.baseUrl + "/account/verify_credentials.json", v, &u, _GET, response_ch}

--- a/errors.go
+++ b/errors.go
@@ -54,12 +54,12 @@ func newApiError(resp *http.Response) *ApiError {
 	}
 }
 
-// ApiError supports the error interface
+// Error supports the error interface
 func (aerr ApiError) Error() string {
 	return fmt.Sprintf("Get %s returned status %d, %s", aerr.URL, aerr.StatusCode, aerr.Body)
 }
 
-// Check to see if an error is a Rate Limiting error. If so, find the next available window in the header.
+// RateLimitCheck checks to see if an error is a Rate Limiting error. If so, find the next available window in the header.
 // Use like so:
 //
 //    if aerr, ok := err.(*ApiError); ok {

--- a/friends_followers.go
+++ b/friends_followers.go
@@ -258,7 +258,7 @@ func (a TwitterApi) FollowUserId(userId int64, v url.Values) (user User, err err
 	return a.postFriendshipsCreateImpl(v)
 }
 
-// FollowUserId follows the user with the specified screenname (username).
+// FollowUser follows the user with the specified screenname (username).
 // This implements the /friendships/create endpoint, though the function name
 // uses the terminology 'follow' as this is most consistent with colloquial Twitter terminology.
 func (a TwitterApi) FollowUser(screenName string) (user User, err error) {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?